### PR TITLE
Add missing port

### DIFF
--- a/crates/talos-rs/src/config.rs
+++ b/crates/talos-rs/src/config.rs
@@ -97,14 +97,23 @@ impl Context {
         self.endpoints.first().map(|e| {
             if e.starts_with("https://") || e.starts_with("http://") {
                 e.clone()
-            } else if e.starts_with('[') || e.contains("::") || e.matches(':').count() > 1 {
-                // IPv6 address (with brackets or raw)
-                format!("https://{}", e)
+            } else if e.starts_with('[') {
+                // IPv6 address with brackets - check if port is specified
+                if e.contains("]:") {
+                    // Has port specified: [::1]:50000
+                    format!("https://{}", e)
+                } else {
+                    // No port: [::1] -> add default port
+                    format!("https://{}:50000", e)
+                }
+            } else if e.contains("::") || e.matches(':').count() > 1 {
+                // Raw IPv6 address without brackets - add brackets and default port
+                format!("https://[{}]:50000", e)
             } else if e.contains(':') {
-                // Has port specified
+                // IPv4 or hostname with port specified
                 format!("https://{}", e)
             } else {
-                // Add default Talos API port
+                // IPv4 or hostname without port - add default Talos API port
                 format!("https://{}:50000", e)
             }
         })
@@ -208,6 +217,7 @@ contexts:
 
     #[test]
     fn test_endpoint_url_with_ipv6() {
+        // IPv6 with brackets and port
         let ctx = Context {
             endpoints: vec!["[2a01:e0a:e4b:aa30::1]:50000".to_string()],
             nodes: vec![],
@@ -220,6 +230,7 @@ contexts:
             Some("https://[2a01:e0a:e4b:aa30::1]:50000".to_string())
         );
 
+        // Raw IPv6 without brackets - should add brackets and default port
         let ctx2 = Context {
             endpoints: vec!["2a01:e0a:e4b:aa30::1".to_string()],
             nodes: vec![],
@@ -229,9 +240,10 @@ contexts:
         };
         assert_eq!(
             ctx2.endpoint_url(),
-            Some("https://2a01:e0a:e4b:aa30::1".to_string())
+            Some("https://[2a01:e0a:e4b:aa30::1]:50000".to_string())
         );
 
+        // IPv6 with brackets and port
         let ctx3 = Context {
             endpoints: vec!["[::1]:50000".to_string()],
             nodes: vec![],
@@ -240,6 +252,16 @@ contexts:
             key: "Yw==".to_string(),
         };
         assert_eq!(ctx3.endpoint_url(), Some("https://[::1]:50000".to_string()));
+
+        // IPv6 with brackets but no port - should add default port
+        let ctx4 = Context {
+            endpoints: vec!["[::1]".to_string()],
+            nodes: vec![],
+            ca: "YQ==".to_string(),
+            crt: "Yg==".to_string(),
+            key: "Yw==".to_string(),
+        };
+        assert_eq!(ctx4.endpoint_url(), Some("https://[::1]:50000".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
@eleboucher #3

Thanks for the PR! Found a couple edge cases with IPv6 handling:

  - Raw IPv6 addresses need brackets in URLs (https://[2a01:...]:50000 not https://2a01:...)
  - IPv6 without ports should get the default :50000 like hostnames do
  - Also handled [::1] (brackets but no port) case

  Updated the logic and tests accordingly.

I will have more time to address issues in like 10 / 12 hours from now.