### PR TITLE
remove hardcoded node ip

### DIFF
--- a/crates/talos-rs/src/talosctl.rs
+++ b/crates/talos-rs/src/talosctl.rs
@@ -157,24 +157,15 @@ pub fn get_discovery_members(node: &str) -> Result<Vec<DiscoveryMember>, TalosEr
 
 /// Get discovery members for a context (async, non-blocking)
 ///
-/// Executes: talosctl --context <context> --nodes 127.0.0.1 get members -o yaml
+/// Executes: talosctl --context <context> get members -o yaml
 ///
 /// This version uses the context name to get the correct certificates and endpoint,
 /// and uses tokio async process to avoid blocking the runtime.
 pub async fn get_discovery_members_for_context(
     context: &str,
 ) -> Result<Vec<DiscoveryMember>, TalosError> {
-    let output = exec_talosctl_async(&[
-        "--context",
-        context,
-        "--nodes",
-        "127.0.0.1",
-        "get",
-        "members",
-        "-o",
-        "yaml",
-    ])
-    .await?;
+    let output =
+        exec_talosctl_async(&["--context", context, "get", "members", "-o", "yaml"]).await?;
     parse_discovery_members_yaml(&output)
 }
 


### PR DESCRIPTION
we can safely remove this option as it will read the nodes in the config 