### PR TITLE
fix: correct vIP filtering logic from 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Ken Udovic"]
 license = "MIT"

--- a/test-clusters/scripts/setup-vip-config.sh
+++ b/test-clusters/scripts/setup-vip-config.sh
@@ -2,13 +2,21 @@
 # setup-vip-config.sh - Configure talosconfig with vIP test scenarios
 #
 # Run this AFTER creating a cluster with:
-#   sudo -E talosctl cluster create --name test-cluster --cidr 10.5.0.0/24 --controlplanes 1 --workers 2
+#   sudo -E $(which talosctl) cluster create --name test-cluster --cidr 10.5.0.0/24 --controlplanes 1 --workers 2
 #
 # This script sets up multiple talosconfig contexts to test the vIP filtering fix.
+#
+# The key scenario we're testing (user's real config):
+#   endpoints: [vip, cp1, cp2, cp3]  <- vIP is only in endpoints
+#   nodes: [cp1, cp2, cp3, w1, w2]   <- CP nodes in both, workers only in nodes
+#
+# The fix should:
+#   - Keep CP nodes (they're in both endpoints AND nodes = real nodes)
+#   - Filter vIP only if it accidentally appears in nodes (it's NOT a real node)
 
 set -e
 
-CLUSTER_NAME="talos-pilot"
+CLUSTER_NAME="test-cluster"
 CP_IP="10.5.0.2"
 WORKER1_IP="10.5.0.3"
 WORKER2_IP="10.5.0.4"
@@ -79,10 +87,57 @@ fi
 
 # Create new config with multiple test contexts
 cat > ~/.talos/config << EOF
-context: vip-with-nodes
+context: user-real-config
 contexts:
-  # Context 1: Normal setup (single endpoint, no nodes specified)
-  # Expected: Works normally, targets endpoint node only
+  # =======================================================================
+  # USER'S REAL CONFIG PATTERN (the main test case)
+  # =======================================================================
+  # This matches the user's production config:
+  #   endpoints: [vip, cp1, cp2, cp3]  <- vIP + CP nodes
+  #   nodes: [cp1, cp2, cp3, w1, w2]   <- CP + worker nodes (NO vIP)
+  #
+  # Expected behavior:
+  #   - All 3 nodes should be targeted (CP and workers)
+  #   - vIP is NOT in nodes, so nothing to filter
+  #   - etcd should show 1/1 members
+  #
+  # NOTE: In test environment, $VIP_HOSTNAME (cluster.local) has TLS issues
+  # because the cert doesn't include that name. Put working endpoint first.
+  # In real production, the vIP would have a proper cert.
+  user-real-config:
+    endpoints:
+      - $CP_IP
+      - $VIP_HOSTNAME
+    nodes:
+      - $CP_IP
+      - $WORKER1_IP
+      - $WORKER2_IP
+    ca: $CA
+    crt: $CRT
+    key: $KEY
+
+  # =======================================================================
+  # MISCONFIGURED: vIP accidentally in nodes list
+  # =======================================================================
+  # This is a misconfiguration where the vIP ended up in nodes.
+  # With the new fix, we can't detect this - the vIP will be kept
+  # because it appears in BOTH endpoints AND nodes.
+  # (We assume if it's in nodes, the user wants to target it)
+  vip-in-nodes-misconfigured:
+    endpoints:
+      - $VIP_HOSTNAME
+    nodes:
+      - $VIP_HOSTNAME
+      - $CP_IP
+      - $WORKER1_IP
+      - $WORKER2_IP
+    ca: $CA
+    crt: $CRT
+    key: $KEY
+
+  # =======================================================================
+  # BASELINE: Normal single endpoint, no nodes
+  # =======================================================================
   normal:
     endpoints:
       - $CP_IP
@@ -90,29 +145,15 @@ contexts:
     crt: $CRT
     key: $KEY
 
-  # Context 2: vIP endpoint with nodes list including the vIP
-  # This is the BUG SCENARIO we fixed:
-  # - endpoint is $VIP_HOSTNAME (resolves to $CP_IP)
-  # - nodes includes $VIP_HOSTNAME AND actual node hostnames
-  # Before fix: vIP would be passed in node header -> empty etcd results
-  # After fix: vIP should be filtered out -> correct etcd results
-  vip-with-nodes:
-    endpoints:
-      - $VIP_HOSTNAME
-    nodes:
-      - $VIP_HOSTNAME
-      - $CP_HOSTNAME
-      - $WORKER1_HOSTNAME
-      - $WORKER2_HOSTNAME
-    ca: $CA
-    crt: $CRT
-    key: $KEY
-
-  # Context 3: IP endpoint with nodes list including the IP
-  # Similar bug scenario but with IP instead of hostname
-  ip-with-nodes:
+  # =======================================================================
+  # ALL NODES AS ENDPOINTS (tests that real nodes aren't filtered)
+  # =======================================================================
+  # When all endpoints are also nodes, they should ALL be kept
+  all-nodes-as-endpoints:
     endpoints:
       - $CP_IP
+      - $WORKER1_IP
+      - $WORKER2_IP
     nodes:
       - $CP_IP
       - $WORKER1_IP
@@ -121,18 +162,9 @@ contexts:
     crt: $CRT
     key: $KEY
 
-  # Context 4: Multiple endpoints (all real nodes)
-  # Tests that we don't break normal multi-endpoint configs
-  multi-endpoint:
-    endpoints:
-      - $CP_IP
-      - $WORKER1_IP
-      - $WORKER2_IP
-    ca: $CA
-    crt: $CRT
-    key: $KEY
-
-  # Context 5: Original cluster context (preserved)
+  # =======================================================================
+  # ORIGINAL CLUSTER CONTEXT (preserved)
+  # =======================================================================
   $CLUSTER_NAME:
     endpoints:
       - $CP_IP
@@ -142,10 +174,10 @@ contexts:
 EOF
 
 echo "  Created contexts:"
+echo "    - user-real-config: User's real config pattern (vIP in endpoints only)"
+echo "    - vip-in-nodes-misconfigured: vIP accidentally in nodes (misconfiguration)"
 echo "    - normal: Single endpoint, no nodes (baseline)"
-echo "    - vip-with-nodes: vIP hostname in both endpoints and nodes (BUG SCENARIO)"
-echo "    - ip-with-nodes: IP in both endpoints and nodes (similar bug)"
-echo "    - multi-endpoint: Multiple real endpoints"
+echo "    - all-nodes-as-endpoints: All nodes also as endpoints"
 echo "    - $CLUSTER_NAME: Original cluster context"
 
 echo ""
@@ -153,22 +185,30 @@ echo "=========================================="
 echo "Setup Complete!"
 echo "=========================================="
 echo ""
-echo "Current context: vip-with-nodes (the bug scenario)"
+echo "Current context: user-real-config"
+echo ""
+echo "Test Scenarios:"
+echo ""
+echo "  1. user-real-config (MAIN TEST - user's real config pattern)"
+echo "     endpoints: [$CP_IP, $VIP_HOSTNAME]"
+echo "     nodes: [$CP_IP, $WORKER1_IP, $WORKER2_IP]"
+echo "     Expected: All 3 nodes targeted, etcd shows 1/1"
+echo "     (Note: CP first due to TLS cert limitations in test env)"
+echo ""
+echo "  2. all-nodes-as-endpoints (verify real nodes aren't filtered)"
+echo "     endpoints: [$CP_IP, $WORKER1_IP, $WORKER2_IP]"
+echo "     nodes: [$CP_IP, $WORKER1_IP, $WORKER2_IP]"
+echo "     Expected: All 3 nodes targeted"
 echo ""
 echo "Test commands:"
-echo "  # Run talos-pilot with the vIP bug scenario"
+echo "  # Run talos-pilot"
 echo "  cargo run --bin talos-pilot"
 echo ""
 echo "  # Check etcd members directly"
 echo "  talosctl etcd members"
 echo ""
 echo "  # Switch contexts"
+echo "  talosctl config context user-real-config"
+echo "  talosctl config context all-nodes-as-endpoints"
 echo "  talosctl config context normal"
-echo "  talosctl config context vip-with-nodes"
-echo "  talosctl config context ip-with-nodes"
-echo ""
-echo "What to verify:"
-echo "  1. In 'vip-with-nodes' context: etcd should show 1/1 (not 0/0)"
-echo "  2. In 'ip-with-nodes' context: etcd should show 1/1 (not 0/0)"
-echo "  3. Cluster view should show all 3 nodes correctly"
 echo ""


### PR DESCRIPTION
The 0.1.4 fix incorrectly filtered ALL endpoints from the nodes list, which removed control plane nodes that legitimately appear in both. This broke configs like:
  - endpoints: [vip, cp1, cp2, cp3]
  - nodes: [cp1, cp2, cp3, w1, w2]

  The corrected logic now only filters endpoints that are NOT also in the nodes list (true vIPs/load balancers). Control plane nodes appearing in both lists are preserved.

  Also fixed kubeconfig and etcd APIs to not use node targeting - these only run on control plane nodes, so targeting workers returned empty results. Added log noise filtering for HTTP/gRPC libraries.