### PR TITLE
fix: etcd status now queries all control plane nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "talos-pilot"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "talos-pilot-core"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "serde",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "talos-pilot-tui"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "arboard",
  "base64",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "talos-rs"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "base64",
  "dirs-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 authors = ["Ken Udovic"]
 license = "MIT"

--- a/crates/talos-pilot-tui/src/components/lifecycle.rs
+++ b/crates/talos-pilot-tui/src/components/lifecycle.rs
@@ -359,8 +359,11 @@ impl LifecycleComponent {
         let etcd_quorum = match client.etcd_members().await {
             Ok(members) => {
                 let total = members.len();
-                // Try to get status to determine healthy members
-                let healthy = match client.etcd_status().await {
+                // Extract control plane hostnames to target status calls
+                let cp_hostnames: Vec<String> =
+                    members.iter().map(|m| m.hostname.clone()).collect();
+                // Try to get status from all control planes
+                let healthy = match client.etcd_status_for_nodes(&cp_hostnames).await {
                     Ok(statuses) => {
                         // Count members with status
                         members


### PR DESCRIPTION
Fixed etcd status calls that only queried a single node, causing "quorum at risk (1/3)" on multi-CP clusters. Added etcd_status_for_nodes() method to target specific nodes. Updated all etcd status consumers (etcd view, lifecycle pre-checks, node operations, cluster summary, diagnostics) to first fetch member hostnames, then query all control planes for accurate quorum display.