### PR TITLE
feat: provide group-level view

### DIFF
--- a/crates/talos-pilot-tui/src/action.rs
+++ b/crates/talos-pilot-tui/src/action.rs
@@ -27,6 +27,8 @@ pub enum Action {
     ShowNodeDetails(String, String), // cluster, node
     /// Show multi-service logs: (node_ip, node_role, active_service_ids, all_service_ids)
     ShowMultiLogs(String, String, Vec<String>, Vec<String>),
+    /// Show multi-node logs: (group_name, node_role, Vec<(hostname, ip)>, services)
+    ShowGroupLogs(String, String, Vec<(String, String)>, Vec<String>),
     /// Show etcd cluster status
     ShowEtcd,
     /// Show processes for a node: (hostname, address)
@@ -46,6 +48,16 @@ pub enum Action {
     ShowWorkloads,
     /// Show storage/disks view for a node: (hostname, address)
     ShowStorage(String, String),
+
+    /// Show group processes: (group_name, Vec<(hostname, ip)>)
+    ShowGroupProcesses(String, Vec<(String, String)>),
+    /// Show group network: (group_name, Vec<(hostname, ip)>)
+    ShowGroupNetwork(String, Vec<(String, String)>),
+    /// Show group storage: (group_name, Vec<(hostname, ip)>)
+    ShowGroupStorage(String, Vec<(String, String)>),
+    /// Show group diagnostics: (group_name, node_role, Vec<(hostname, ip)>, cp_endpoint)
+    ShowGroupDiagnostics(String, String, Vec<(String, String)>, Option<String>),
+
     /// Show node operations overlay: (hostname, address, is_controlplane)
     ShowNodeOperations(String, String, bool),
     /// Show rolling operations overlay with node list: Vec<(hostname, address, is_controlplane)>

--- a/crates/talos-pilot-tui/src/app.rs
+++ b/crates/talos-pilot-tui/src/app.rs
@@ -1273,6 +1273,9 @@ impl App {
 
                 // Fetch processes from all nodes
                 if let Some(client) = self.cluster.client() {
+                    // Set the base cluster client for group refresh capability
+                    processes.set_client(client.clone());
+
                     for (hostname, ip) in &nodes {
                         let node_client = client.with_node(ip);
                         match node_client.processes().await {
@@ -1305,6 +1308,9 @@ impl App {
 
                 // Fetch network stats from all nodes
                 if let Some(client) = self.cluster.client() {
+                    // Set the base cluster client for group refresh capability
+                    network.set_client(client.clone());
+
                     for (hostname, ip) in &nodes {
                         let node_client = client.with_node(ip);
                         match node_client.network_device_stats().await {
@@ -1338,6 +1344,9 @@ impl App {
                 // Get context and config from cluster component
                 let context = self.cluster.current_context_name().map(|s| s.to_string());
                 let config_path = self.cluster.config_path().map(|s| s.to_string());
+
+                // Set context and config for group refresh capability
+                storage.set_context(context.clone(), config_path.clone());
 
                 // Fetch storage info from all nodes using talosctl
                 for (hostname, ip) in &nodes {
@@ -1388,6 +1397,9 @@ impl App {
 
                 // Fetch diagnostics from all nodes
                 if let Some(client) = self.cluster.client() {
+                    // Set the base cluster client for group refresh capability
+                    diagnostics.set_client(client.clone());
+
                     for (hostname, ip) in &nodes {
                         let node_client = client.with_node(ip);
 

--- a/crates/talos-pilot-tui/src/app.rs
+++ b/crates/talos-pilot-tui/src/app.rs
@@ -994,11 +994,7 @@ impl App {
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!(
-                                    "Failed to fetch logs from {}: {}",
-                                    hostname,
-                                    e
-                                );
+                                tracing::warn!("Failed to fetch logs from {}: {}", hostname, e);
                             }
                         }
                     }
@@ -1269,7 +1265,8 @@ impl App {
                 );
 
                 // Create processes component in group mode
-                let mut processes = ProcessesComponent::new_group(group_name.clone(), nodes.clone());
+                let mut processes =
+                    ProcessesComponent::new_group(group_name.clone(), nodes.clone());
 
                 // Fetch processes from all nodes
                 if let Some(client) = self.cluster.client() {
@@ -1286,7 +1283,11 @@ impl App {
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!("Failed to fetch processes from {}: {}", hostname, e);
+                                tracing::warn!(
+                                    "Failed to fetch processes from {}: {}",
+                                    hostname,
+                                    e
+                                );
                             }
                         }
                     }
@@ -1304,7 +1305,8 @@ impl App {
                 );
 
                 // Create network component in group mode
-                let mut network = NetworkStatsComponent::new_group(group_name.clone(), nodes.clone());
+                let mut network =
+                    NetworkStatsComponent::new_group(group_name.clone(), nodes.clone());
 
                 // Fetch network stats from all nodes
                 if let Some(client) = self.cluster.client() {
@@ -1321,7 +1323,11 @@ impl App {
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!("Failed to fetch network stats from {}: {}", hostname, e);
+                                tracing::warn!(
+                                    "Failed to fetch network stats from {}: {}",
+                                    hostname,
+                                    e
+                                );
                             }
                         }
                     }
@@ -1354,16 +1360,32 @@ impl App {
                     let node_ip = ip.split(':').next().unwrap_or(ip);
                     if let Some(ctx) = &context {
                         // Fetch disks
-                        match talos_rs::get_disks_for_node(ctx, node_ip, config_path.as_deref()).await {
+                        match talos_rs::get_disks_for_node(ctx, node_ip, config_path.as_deref())
+                            .await
+                        {
                             Ok(disks) => {
                                 // Fetch volumes
-                                match talos_rs::get_volume_status_for_node(ctx, node_ip, config_path.as_deref()).await {
+                                match talos_rs::get_volume_status_for_node(
+                                    ctx,
+                                    node_ip,
+                                    config_path.as_deref(),
+                                )
+                                .await
+                                {
                                     Ok(volumes) => {
                                         storage.add_node_storage(hostname.clone(), disks, volumes);
                                     }
                                     Err(e) => {
-                                        tracing::warn!("Failed to fetch volumes from {}: {}", hostname, e);
-                                        storage.add_node_storage(hostname.clone(), disks, Vec::new());
+                                        tracing::warn!(
+                                            "Failed to fetch volumes from {}: {}",
+                                            hostname,
+                                            e
+                                        );
+                                        storage.add_node_storage(
+                                            hostname.clone(),
+                                            disks,
+                                            Vec::new(),
+                                        );
                                     }
                                 }
                             }
@@ -1422,7 +1444,11 @@ impl App {
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!("Failed to fetch diagnostics from {}: {}", hostname, e);
+                                tracing::warn!(
+                                    "Failed to fetch diagnostics from {}: {}",
+                                    hostname,
+                                    e
+                                );
                             }
                         }
                     }

--- a/crates/talos-pilot-tui/src/components/cluster.rs
+++ b/crates/talos-pilot-tui/src/components/cluster.rs
@@ -838,7 +838,11 @@ impl ClusterComponent {
                 if nodes.is_empty() {
                     None
                 } else {
-                    Some(("Control Plane".to_string(), "controlplane".to_string(), nodes))
+                    Some((
+                        "Control Plane".to_string(),
+                        "controlplane".to_string(),
+                        nodes,
+                    ))
                 }
             }
             NodeListItem::WorkersHeader(cluster_idx) => {
@@ -1150,7 +1154,9 @@ impl Component for ClusterComponent {
                 if let Some((group_name, role, nodes)) = self.current_group_nodes() {
                     let services = self.common_services_for_group(&nodes);
                     if !services.is_empty() {
-                        Ok(Some(Action::ShowGroupLogs(group_name, role, nodes, services)))
+                        Ok(Some(Action::ShowGroupLogs(
+                            group_name, role, nodes, services,
+                        )))
                     } else {
                         Ok(None)
                     }
@@ -1401,341 +1407,6 @@ impl Component for ClusterComponent {
         frame.render_widget(footer, layout[2]);
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Create a test ServiceInfo with the given ID
-    fn make_service(id: &str) -> ServiceInfo {
-        ServiceInfo {
-            id: id.to_string(),
-            state: "Running".to_string(),
-            health: None,
-        }
-    }
-
-    /// Create a test VersionInfo for a node
-    fn make_version_info(node: &str) -> VersionInfo {
-        VersionInfo {
-            node: node.to_string(),
-            version: "v1.8.0".to_string(),
-            sha: "abc123".to_string(),
-            built: "2024-01-01".to_string(),
-            go_version: "1.22".to_string(),
-            os: "linux".to_string(),
-            arch: "amd64".to_string(),
-            platform: "metal".to_string(),
-        }
-    }
-
-    /// Create a test NodeServices for a node with given service IDs
-    fn make_node_services(node: &str, service_ids: &[&str]) -> NodeServices {
-        NodeServices {
-            node: node.to_string(),
-            services: service_ids.iter().map(|id| make_service(id)).collect(),
-        }
-    }
-
-    /// Create a ClusterComponent with test data
-    fn create_test_component() -> ClusterComponent {
-        let mut component = ClusterComponent::new(None, None);
-
-        // Create a cluster with controlplane and worker nodes
-        let cluster = ClusterData {
-            name: "test-cluster".to_string(),
-            client: None,
-            connected: true,
-            error: None,
-            versions: vec![
-                make_version_info("cp-node-1"),
-                make_version_info("cp-node-2"),
-                make_version_info("worker-1"),
-                make_version_info("worker-2"),
-            ],
-            services: vec![
-                // Control plane nodes have etcd
-                make_node_services("cp-node-1", &["etcd", "kubelet", "apid", "containerd"]),
-                make_node_services("cp-node-2", &["etcd", "kubelet", "apid", "containerd"]),
-                // Worker nodes do not have etcd
-                make_node_services("worker-1", &["kubelet", "apid", "containerd"]),
-                make_node_services("worker-2", &["kubelet", "apid", "containerd"]),
-            ],
-            memory: Vec::new(),
-            load_avg: Vec::new(),
-            cpu_info: Vec::new(),
-            etcd_members: Vec::new(),
-            discovery_members: Vec::new(),
-            etcd_summary: None,
-            node_ips: HashMap::from([
-                ("cp-node-1".to_string(), "10.0.0.1".to_string()),
-                ("cp-node-2".to_string(), "10.0.0.2".to_string()),
-                ("worker-1".to_string(), "10.0.0.3".to_string()),
-                ("worker-2".to_string(), "10.0.0.4".to_string()),
-            ]),
-            expanded: true,
-            controlplane_expanded: true,
-            workers_expanded: true,
-        };
-
-        component.clusters.push(cluster);
-        component.active_cluster = 0;
-        component
-    }
-
-    // ==========================================================================
-    // Tests for current_group_nodes()
-    // ==========================================================================
-
-    #[test]
-    fn test_current_group_nodes_returns_none_for_cluster_header() {
-        let mut component = create_test_component();
-        component.selected_item = NodeListItem::ClusterHeader(0);
-
-        let result = component.current_group_nodes();
-        assert!(result.is_none(), "ClusterHeader should not return group nodes");
-    }
-
-    #[test]
-    fn test_current_group_nodes_returns_controlplane_when_on_controlplane_header() {
-        let mut component = create_test_component();
-        component.selected_item = NodeListItem::ControlPlaneHeader(0);
-
-        let result = component.current_group_nodes();
-        assert!(result.is_some(), "ControlPlaneHeader should return group nodes");
-
-        let (group_name, role, nodes) = result.unwrap();
-        assert_eq!(group_name, "Control Plane");
-        assert_eq!(role, "controlplane");
-        assert_eq!(nodes.len(), 2, "Should have 2 control plane nodes");
-
-        // Verify node hostnames and IPs
-        assert!(nodes.iter().any(|(h, ip)| h == "cp-node-1" && ip == "10.0.0.1"));
-        assert!(nodes.iter().any(|(h, ip)| h == "cp-node-2" && ip == "10.0.0.2"));
-    }
-
-    #[test]
-    fn test_current_group_nodes_returns_workers_when_on_workers_header() {
-        let mut component = create_test_component();
-        component.selected_item = NodeListItem::WorkersHeader(0);
-
-        let result = component.current_group_nodes();
-        assert!(result.is_some(), "WorkersHeader should return group nodes");
-
-        let (group_name, role, nodes) = result.unwrap();
-        assert_eq!(group_name, "Workers");
-        assert_eq!(role, "worker");
-        assert_eq!(nodes.len(), 2, "Should have 2 worker nodes");
-
-        // Verify node hostnames and IPs
-        assert!(nodes.iter().any(|(h, ip)| h == "worker-1" && ip == "10.0.0.3"));
-        assert!(nodes.iter().any(|(h, ip)| h == "worker-2" && ip == "10.0.0.4"));
-    }
-
-    #[test]
-    fn test_current_group_nodes_returns_none_when_no_controlplane_nodes() {
-        let mut component = ClusterComponent::new(None, None);
-
-        // Create a cluster with only workers (no etcd services)
-        let cluster = ClusterData {
-            name: "workers-only".to_string(),
-            client: None,
-            connected: true,
-            error: None,
-            versions: vec![make_version_info("worker-1")],
-            services: vec![make_node_services("worker-1", &["kubelet", "containerd"])],
-            memory: Vec::new(),
-            load_avg: Vec::new(),
-            cpu_info: Vec::new(),
-            etcd_members: Vec::new(),
-            discovery_members: Vec::new(),
-            etcd_summary: None,
-            node_ips: HashMap::from([("worker-1".to_string(), "10.0.0.1".to_string())]),
-            expanded: true,
-            controlplane_expanded: true,
-            workers_expanded: true,
-        };
-
-        component.clusters.push(cluster);
-        component.selected_item = NodeListItem::ControlPlaneHeader(0);
-
-        let result = component.current_group_nodes();
-        assert!(
-            result.is_none(),
-            "ControlPlaneHeader with no controlplane nodes should return None"
-        );
-    }
-
-    #[test]
-    fn test_current_group_nodes_returns_none_when_no_worker_nodes() {
-        let mut component = ClusterComponent::new(None, None);
-
-        // Create a cluster with only control plane nodes
-        let cluster = ClusterData {
-            name: "cp-only".to_string(),
-            client: None,
-            connected: true,
-            error: None,
-            versions: vec![make_version_info("cp-node-1")],
-            services: vec![make_node_services("cp-node-1", &["etcd", "kubelet"])],
-            memory: Vec::new(),
-            load_avg: Vec::new(),
-            cpu_info: Vec::new(),
-            etcd_members: Vec::new(),
-            discovery_members: Vec::new(),
-            etcd_summary: None,
-            node_ips: HashMap::from([("cp-node-1".to_string(), "10.0.0.1".to_string())]),
-            expanded: true,
-            controlplane_expanded: true,
-            workers_expanded: true,
-        };
-
-        component.clusters.push(cluster);
-        component.selected_item = NodeListItem::WorkersHeader(0);
-
-        let result = component.current_group_nodes();
-        assert!(
-            result.is_none(),
-            "WorkersHeader with no worker nodes should return None"
-        );
-    }
-
-    #[test]
-    fn test_current_group_nodes_returns_none_for_individual_nodes() {
-        let mut component = create_test_component();
-
-        // Test ControlPlaneNode
-        component.selected_item = NodeListItem::ControlPlaneNode(0, 0);
-        assert!(
-            component.current_group_nodes().is_none(),
-            "ControlPlaneNode should return None"
-        );
-
-        // Test WorkerNode
-        component.selected_item = NodeListItem::WorkerNode(0, 0);
-        assert!(
-            component.current_group_nodes().is_none(),
-            "WorkerNode should return None"
-        );
-    }
-
-    // ==========================================================================
-    // Tests for common_services_for_group()
-    // ==========================================================================
-
-    #[test]
-    fn test_common_services_for_group_returns_empty_for_empty_nodes() {
-        let component = create_test_component();
-
-        let result = component.common_services_for_group(&[]);
-        assert!(result.is_empty(), "Empty nodes should return empty services");
-    }
-
-    #[test]
-    fn test_common_services_for_group_returns_all_services_for_single_node() {
-        let component = create_test_component();
-
-        // Single control plane node
-        let nodes = vec![("cp-node-1".to_string(), "10.0.0.1".to_string())];
-
-        let result = component.common_services_for_group(&nodes);
-        assert_eq!(result.len(), 4, "Single node should return all its services");
-        assert!(result.contains(&"etcd".to_string()));
-        assert!(result.contains(&"kubelet".to_string()));
-        assert!(result.contains(&"apid".to_string()));
-        assert!(result.contains(&"containerd".to_string()));
-    }
-
-    #[test]
-    fn test_common_services_for_group_returns_intersection_for_multiple_nodes() {
-        let component = create_test_component();
-
-        // Control plane and worker nodes have different services
-        let nodes = vec![
-            ("cp-node-1".to_string(), "10.0.0.1".to_string()),
-            ("worker-1".to_string(), "10.0.0.3".to_string()),
-        ];
-
-        let result = component.common_services_for_group(&nodes);
-
-        // Common services: kubelet, apid, containerd (not etcd which is only on cp)
-        assert_eq!(
-            result.len(),
-            3,
-            "Should return only common services (intersection)"
-        );
-        assert!(result.contains(&"kubelet".to_string()));
-        assert!(result.contains(&"apid".to_string()));
-        assert!(result.contains(&"containerd".to_string()));
-        assert!(
-            !result.contains(&"etcd".to_string()),
-            "etcd should not be in common services"
-        );
-    }
-
-    #[test]
-    fn test_common_services_for_group_returns_empty_when_no_common_services() {
-        let mut component = ClusterComponent::new(None, None);
-
-        // Create nodes with completely different services
-        let cluster = ClusterData {
-            name: "test".to_string(),
-            client: None,
-            connected: true,
-            error: None,
-            versions: vec![make_version_info("node-a"), make_version_info("node-b")],
-            services: vec![
-                make_node_services("node-a", &["service-a", "service-b"]),
-                make_node_services("node-b", &["service-c", "service-d"]),
-            ],
-            memory: Vec::new(),
-            load_avg: Vec::new(),
-            cpu_info: Vec::new(),
-            etcd_members: Vec::new(),
-            discovery_members: Vec::new(),
-            etcd_summary: None,
-            node_ips: HashMap::from([
-                ("node-a".to_string(), "10.0.0.1".to_string()),
-                ("node-b".to_string(), "10.0.0.2".to_string()),
-            ]),
-            expanded: true,
-            controlplane_expanded: true,
-            workers_expanded: true,
-        };
-
-        component.clusters.push(cluster);
-        component.active_cluster = 0;
-
-        let nodes = vec![
-            ("node-a".to_string(), "10.0.0.1".to_string()),
-            ("node-b".to_string(), "10.0.0.2".to_string()),
-        ];
-
-        let result = component.common_services_for_group(&nodes);
-        assert!(
-            result.is_empty(),
-            "Nodes with no common services should return empty"
-        );
-    }
-
-    #[test]
-    fn test_common_services_for_group_sorts_results() {
-        let component = create_test_component();
-
-        // Use two control plane nodes that have the same services
-        let nodes = vec![
-            ("cp-node-1".to_string(), "10.0.0.1".to_string()),
-            ("cp-node-2".to_string(), "10.0.0.2".to_string()),
-        ];
-
-        let result = component.common_services_for_group(&nodes);
-
-        // Verify the result is sorted
-        let mut sorted = result.clone();
-        sorted.sort();
-        assert_eq!(result, sorted, "Results should be sorted alphabetically");
     }
 }
 
@@ -2482,5 +2153,369 @@ impl ClusterComponent {
 
             frame.render_widget(Paragraph::new(svc_lines), panel_layout[1]);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a test ServiceInfo with the given ID
+    fn make_service(id: &str) -> ServiceInfo {
+        ServiceInfo {
+            id: id.to_string(),
+            state: "Running".to_string(),
+            health: None,
+        }
+    }
+
+    /// Create a test VersionInfo for a node
+    fn make_version_info(node: &str) -> VersionInfo {
+        VersionInfo {
+            node: node.to_string(),
+            version: "v1.8.0".to_string(),
+            sha: "abc123".to_string(),
+            built: "2024-01-01".to_string(),
+            go_version: "1.22".to_string(),
+            os: "linux".to_string(),
+            arch: "amd64".to_string(),
+            platform: "metal".to_string(),
+        }
+    }
+
+    /// Create a test NodeServices for a node with given service IDs
+    fn make_node_services(node: &str, service_ids: &[&str]) -> NodeServices {
+        NodeServices {
+            node: node.to_string(),
+            services: service_ids.iter().map(|id| make_service(id)).collect(),
+        }
+    }
+
+    /// Create a ClusterComponent with test data
+    fn create_test_component() -> ClusterComponent {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create a cluster with controlplane and worker nodes
+        let cluster = ClusterData {
+            name: "test-cluster".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![
+                make_version_info("cp-node-1"),
+                make_version_info("cp-node-2"),
+                make_version_info("worker-1"),
+                make_version_info("worker-2"),
+            ],
+            services: vec![
+                // Control plane nodes have etcd
+                make_node_services("cp-node-1", &["etcd", "kubelet", "apid", "containerd"]),
+                make_node_services("cp-node-2", &["etcd", "kubelet", "apid", "containerd"]),
+                // Worker nodes do not have etcd
+                make_node_services("worker-1", &["kubelet", "apid", "containerd"]),
+                make_node_services("worker-2", &["kubelet", "apid", "containerd"]),
+            ],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([
+                ("cp-node-1".to_string(), "10.0.0.1".to_string()),
+                ("cp-node-2".to_string(), "10.0.0.2".to_string()),
+                ("worker-1".to_string(), "10.0.0.3".to_string()),
+                ("worker-2".to_string(), "10.0.0.4".to_string()),
+            ]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.active_cluster = 0;
+        component
+    }
+
+    // ==========================================================================
+    // Tests for current_group_nodes()
+    // ==========================================================================
+
+    #[test]
+    fn test_current_group_nodes_returns_none_for_cluster_header() {
+        let mut component = create_test_component();
+        component.selected_item = NodeListItem::ClusterHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(
+            result.is_none(),
+            "ClusterHeader should not return group nodes"
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_controlplane_when_on_controlplane_header() {
+        let mut component = create_test_component();
+        component.selected_item = NodeListItem::ControlPlaneHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(
+            result.is_some(),
+            "ControlPlaneHeader should return group nodes"
+        );
+
+        let (group_name, role, nodes) = result.unwrap();
+        assert_eq!(group_name, "Control Plane");
+        assert_eq!(role, "controlplane");
+        assert_eq!(nodes.len(), 2, "Should have 2 control plane nodes");
+
+        // Verify node hostnames and IPs
+        assert!(
+            nodes
+                .iter()
+                .any(|(h, ip)| h == "cp-node-1" && ip == "10.0.0.1")
+        );
+        assert!(
+            nodes
+                .iter()
+                .any(|(h, ip)| h == "cp-node-2" && ip == "10.0.0.2")
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_workers_when_on_workers_header() {
+        let mut component = create_test_component();
+        component.selected_item = NodeListItem::WorkersHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(result.is_some(), "WorkersHeader should return group nodes");
+
+        let (group_name, role, nodes) = result.unwrap();
+        assert_eq!(group_name, "Workers");
+        assert_eq!(role, "worker");
+        assert_eq!(nodes.len(), 2, "Should have 2 worker nodes");
+
+        // Verify node hostnames and IPs
+        assert!(
+            nodes
+                .iter()
+                .any(|(h, ip)| h == "worker-1" && ip == "10.0.0.3")
+        );
+        assert!(
+            nodes
+                .iter()
+                .any(|(h, ip)| h == "worker-2" && ip == "10.0.0.4")
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_none_when_no_controlplane_nodes() {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create a cluster with only workers (no etcd services)
+        let cluster = ClusterData {
+            name: "workers-only".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![make_version_info("worker-1")],
+            services: vec![make_node_services("worker-1", &["kubelet", "containerd"])],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([("worker-1".to_string(), "10.0.0.1".to_string())]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.selected_item = NodeListItem::ControlPlaneHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(
+            result.is_none(),
+            "ControlPlaneHeader with no controlplane nodes should return None"
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_none_when_no_worker_nodes() {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create a cluster with only control plane nodes
+        let cluster = ClusterData {
+            name: "cp-only".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![make_version_info("cp-node-1")],
+            services: vec![make_node_services("cp-node-1", &["etcd", "kubelet"])],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([("cp-node-1".to_string(), "10.0.0.1".to_string())]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.selected_item = NodeListItem::WorkersHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(
+            result.is_none(),
+            "WorkersHeader with no worker nodes should return None"
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_none_for_individual_nodes() {
+        let mut component = create_test_component();
+
+        // Test ControlPlaneNode
+        component.selected_item = NodeListItem::ControlPlaneNode(0, 0);
+        assert!(
+            component.current_group_nodes().is_none(),
+            "ControlPlaneNode should return None"
+        );
+
+        // Test WorkerNode
+        component.selected_item = NodeListItem::WorkerNode(0, 0);
+        assert!(
+            component.current_group_nodes().is_none(),
+            "WorkerNode should return None"
+        );
+    }
+
+    // ==========================================================================
+    // Tests for common_services_for_group()
+    // ==========================================================================
+
+    #[test]
+    fn test_common_services_for_group_returns_empty_for_empty_nodes() {
+        let component = create_test_component();
+
+        let result = component.common_services_for_group(&[]);
+        assert!(
+            result.is_empty(),
+            "Empty nodes should return empty services"
+        );
+    }
+
+    #[test]
+    fn test_common_services_for_group_returns_all_services_for_single_node() {
+        let component = create_test_component();
+
+        // Single control plane node
+        let nodes = vec![("cp-node-1".to_string(), "10.0.0.1".to_string())];
+
+        let result = component.common_services_for_group(&nodes);
+        assert_eq!(
+            result.len(),
+            4,
+            "Single node should return all its services"
+        );
+        assert!(result.contains(&"etcd".to_string()));
+        assert!(result.contains(&"kubelet".to_string()));
+        assert!(result.contains(&"apid".to_string()));
+        assert!(result.contains(&"containerd".to_string()));
+    }
+
+    #[test]
+    fn test_common_services_for_group_returns_intersection_for_multiple_nodes() {
+        let component = create_test_component();
+
+        // Control plane and worker nodes have different services
+        let nodes = vec![
+            ("cp-node-1".to_string(), "10.0.0.1".to_string()),
+            ("worker-1".to_string(), "10.0.0.3".to_string()),
+        ];
+
+        let result = component.common_services_for_group(&nodes);
+
+        // Common services: kubelet, apid, containerd (not etcd which is only on cp)
+        assert_eq!(
+            result.len(),
+            3,
+            "Should return only common services (intersection)"
+        );
+        assert!(result.contains(&"kubelet".to_string()));
+        assert!(result.contains(&"apid".to_string()));
+        assert!(result.contains(&"containerd".to_string()));
+        assert!(
+            !result.contains(&"etcd".to_string()),
+            "etcd should not be in common services"
+        );
+    }
+
+    #[test]
+    fn test_common_services_for_group_returns_empty_when_no_common_services() {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create nodes with completely different services
+        let cluster = ClusterData {
+            name: "test".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![make_version_info("node-a"), make_version_info("node-b")],
+            services: vec![
+                make_node_services("node-a", &["service-a", "service-b"]),
+                make_node_services("node-b", &["service-c", "service-d"]),
+            ],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([
+                ("node-a".to_string(), "10.0.0.1".to_string()),
+                ("node-b".to_string(), "10.0.0.2".to_string()),
+            ]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.active_cluster = 0;
+
+        let nodes = vec![
+            ("node-a".to_string(), "10.0.0.1".to_string()),
+            ("node-b".to_string(), "10.0.0.2".to_string()),
+        ];
+
+        let result = component.common_services_for_group(&nodes);
+        assert!(
+            result.is_empty(),
+            "Nodes with no common services should return empty"
+        );
+    }
+
+    #[test]
+    fn test_common_services_for_group_sorts_results() {
+        let component = create_test_component();
+
+        // Use two control plane nodes that have the same services
+        let nodes = vec![
+            ("cp-node-1".to_string(), "10.0.0.1".to_string()),
+            ("cp-node-2".to_string(), "10.0.0.2".to_string()),
+        ];
+
+        let result = component.common_services_for_group(&nodes);
+
+        // Verify the result is sorted
+        let mut sorted = result.clone();
+        sorted.sort();
+        assert_eq!(result, sorted, "Results should be sorted alphabetically");
     }
 }

--- a/crates/talos-pilot-tui/src/components/cluster.rs
+++ b/crates/talos-pilot-tui/src/components/cluster.rs
@@ -818,6 +818,84 @@ impl ClusterComponent {
         }
     }
 
+    /// If the current selection is a group header (ControlPlaneHeader or WorkersHeader),
+    /// returns (group_name, role, nodes) where nodes is Vec<(hostname, ip)>.
+    /// Returns None if the selection is not a group header.
+    #[allow(clippy::type_complexity)]
+    fn current_group_nodes(&self) -> Option<(String, String, Vec<(String, String)>)> {
+        match &self.selected_item {
+            NodeListItem::ControlPlaneHeader(cluster_idx) => {
+                let cluster = self.clusters.get(*cluster_idx)?;
+                let cp_nodes = self.controlplane_nodes_for(*cluster_idx);
+                let nodes: Vec<(String, String)> = cp_nodes
+                    .iter()
+                    .filter_map(|(_, v)| {
+                        let hostname = v.node.clone();
+                        let ip = cluster.node_ips.get(&hostname).cloned()?;
+                        Some((hostname, ip))
+                    })
+                    .collect();
+                if nodes.is_empty() {
+                    None
+                } else {
+                    Some(("Control Plane".to_string(), "controlplane".to_string(), nodes))
+                }
+            }
+            NodeListItem::WorkersHeader(cluster_idx) => {
+                let cluster = self.clusters.get(*cluster_idx)?;
+                let worker_nodes = self.worker_nodes_for(*cluster_idx);
+                let nodes: Vec<(String, String)> = worker_nodes
+                    .iter()
+                    .filter_map(|(_, v)| {
+                        let hostname = v.node.clone();
+                        let ip = cluster.node_ips.get(&hostname).cloned()?;
+                        Some((hostname, ip))
+                    })
+                    .collect();
+                if nodes.is_empty() {
+                    None
+                } else {
+                    Some(("Workers".to_string(), "worker".to_string(), nodes))
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Find services that are common to all nodes in a group.
+    /// Returns services present on every node.
+    fn common_services_for_group(&self, nodes: &[(String, String)]) -> Vec<String> {
+        if nodes.is_empty() {
+            return Vec::new();
+        }
+
+        // Get service sets for each node
+        let mut service_sets: Vec<std::collections::HashSet<String>> = Vec::new();
+
+        for (hostname, _) in nodes {
+            if let Some(services) = self.get_node_services(hostname) {
+                let set: std::collections::HashSet<String> =
+                    services.iter().map(|s| s.id.clone()).collect();
+                service_sets.push(set);
+            }
+        }
+
+        if service_sets.is_empty() {
+            return Vec::new();
+        }
+
+        // Find intersection of all service sets
+        let mut common = service_sets[0].clone();
+        for set in service_sets.iter().skip(1) {
+            common = common.intersection(set).cloned().collect();
+        }
+
+        // Convert to sorted Vec for consistent ordering
+        let mut result: Vec<String> = common.into_iter().collect();
+        result.sort();
+        result
+    }
+
     /// Navigate to the currently selected menu item (1-based index, 0 = on node)
     fn navigate_to_selected_menu(&self) -> Result<Option<Action>> {
         if self.selected_menu_item == 0 || self.selected_menu_item > NavMenuItem::ALL.len() {
@@ -1066,9 +1144,18 @@ impl Component for ClusterComponent {
                 }
             }
 
-            // 'l' / 'L' - show logs (all services for node)
+            // 'l' / 'L' - show logs (all services for node or group)
             KeyCode::Char('l') | KeyCode::Char('L') => {
-                if let Some(node_name) = self.current_node_name() {
+                // First check if we're on a group header
+                if let Some((group_name, role, nodes)) = self.current_group_nodes() {
+                    let services = self.common_services_for_group(&nodes);
+                    if !services.is_empty() {
+                        Ok(Some(Action::ShowGroupLogs(group_name, role, nodes, services)))
+                    } else {
+                        Ok(None)
+                    }
+                } else if let Some(node_name) = self.current_node_name() {
+                    // Fall back to single node behavior
                     let service_ids = self.current_service_ids();
                     if !service_ids.is_empty() {
                         let node_role = self.current_node_role();
@@ -1094,7 +1181,10 @@ impl Component for ClusterComponent {
             // Direct hotkeys for screens (always work)
             KeyCode::Char('e') => Ok(Some(Action::ShowEtcd)),
             KeyCode::Char('p') => {
-                if let Some(node_name) = self.current_node_name() {
+                // Check if on a group header first
+                if let Some((group_name, _role, nodes)) = self.current_group_nodes() {
+                    Ok(Some(Action::ShowGroupProcesses(group_name, nodes)))
+                } else if let Some(node_name) = self.current_node_name() {
                     let node_ip = self
                         .node_ips()
                         .get(&node_name)
@@ -1106,7 +1196,10 @@ impl Component for ClusterComponent {
                 }
             }
             KeyCode::Char('n') => {
-                if let Some(node_name) = self.current_node_name() {
+                // Check if on a group header first
+                if let Some((group_name, _role, nodes)) = self.current_group_nodes() {
+                    Ok(Some(Action::ShowGroupNetwork(group_name, nodes)))
+                } else if let Some(node_name) = self.current_node_name() {
                     let node_ip = self
                         .node_ips()
                         .get(&node_name)
@@ -1118,7 +1211,10 @@ impl Component for ClusterComponent {
                 }
             }
             KeyCode::Char('s') => {
-                if let Some(node_name) = self.current_node_name() {
+                // Check if on a group header first
+                if let Some((group_name, _role, nodes)) = self.current_group_nodes() {
+                    Ok(Some(Action::ShowGroupStorage(group_name, nodes)))
+                } else if let Some(node_name) = self.current_node_name() {
                     let node_ip = self
                         .node_ips()
                         .get(&node_name)
@@ -1130,7 +1226,21 @@ impl Component for ClusterComponent {
                 }
             }
             KeyCode::Char('d') => {
-                if let Some(node_name) = self.current_node_name() {
+                // Check if on a group header first
+                if let Some((group_name, role, nodes)) = self.current_group_nodes() {
+                    // For worker groups, provide a control plane endpoint to fetch kubeconfig from
+                    let cp_endpoint = if role == "worker" {
+                        self.get_controlplane_endpoint()
+                    } else {
+                        None
+                    };
+                    Ok(Some(Action::ShowGroupDiagnostics(
+                        group_name,
+                        role,
+                        nodes,
+                        cp_endpoint,
+                    )))
+                } else if let Some(node_name) = self.current_node_name() {
                     let node_ip = self
                         .node_ips()
                         .get(&node_name)
@@ -1291,6 +1401,341 @@ impl Component for ClusterComponent {
         frame.render_widget(footer, layout[2]);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a test ServiceInfo with the given ID
+    fn make_service(id: &str) -> ServiceInfo {
+        ServiceInfo {
+            id: id.to_string(),
+            state: "Running".to_string(),
+            health: None,
+        }
+    }
+
+    /// Create a test VersionInfo for a node
+    fn make_version_info(node: &str) -> VersionInfo {
+        VersionInfo {
+            node: node.to_string(),
+            version: "v1.8.0".to_string(),
+            sha: "abc123".to_string(),
+            built: "2024-01-01".to_string(),
+            go_version: "1.22".to_string(),
+            os: "linux".to_string(),
+            arch: "amd64".to_string(),
+            platform: "metal".to_string(),
+        }
+    }
+
+    /// Create a test NodeServices for a node with given service IDs
+    fn make_node_services(node: &str, service_ids: &[&str]) -> NodeServices {
+        NodeServices {
+            node: node.to_string(),
+            services: service_ids.iter().map(|id| make_service(id)).collect(),
+        }
+    }
+
+    /// Create a ClusterComponent with test data
+    fn create_test_component() -> ClusterComponent {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create a cluster with controlplane and worker nodes
+        let cluster = ClusterData {
+            name: "test-cluster".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![
+                make_version_info("cp-node-1"),
+                make_version_info("cp-node-2"),
+                make_version_info("worker-1"),
+                make_version_info("worker-2"),
+            ],
+            services: vec![
+                // Control plane nodes have etcd
+                make_node_services("cp-node-1", &["etcd", "kubelet", "apid", "containerd"]),
+                make_node_services("cp-node-2", &["etcd", "kubelet", "apid", "containerd"]),
+                // Worker nodes do not have etcd
+                make_node_services("worker-1", &["kubelet", "apid", "containerd"]),
+                make_node_services("worker-2", &["kubelet", "apid", "containerd"]),
+            ],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([
+                ("cp-node-1".to_string(), "10.0.0.1".to_string()),
+                ("cp-node-2".to_string(), "10.0.0.2".to_string()),
+                ("worker-1".to_string(), "10.0.0.3".to_string()),
+                ("worker-2".to_string(), "10.0.0.4".to_string()),
+            ]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.active_cluster = 0;
+        component
+    }
+
+    // ==========================================================================
+    // Tests for current_group_nodes()
+    // ==========================================================================
+
+    #[test]
+    fn test_current_group_nodes_returns_none_for_cluster_header() {
+        let mut component = create_test_component();
+        component.selected_item = NodeListItem::ClusterHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(result.is_none(), "ClusterHeader should not return group nodes");
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_controlplane_when_on_controlplane_header() {
+        let mut component = create_test_component();
+        component.selected_item = NodeListItem::ControlPlaneHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(result.is_some(), "ControlPlaneHeader should return group nodes");
+
+        let (group_name, role, nodes) = result.unwrap();
+        assert_eq!(group_name, "Control Plane");
+        assert_eq!(role, "controlplane");
+        assert_eq!(nodes.len(), 2, "Should have 2 control plane nodes");
+
+        // Verify node hostnames and IPs
+        assert!(nodes.iter().any(|(h, ip)| h == "cp-node-1" && ip == "10.0.0.1"));
+        assert!(nodes.iter().any(|(h, ip)| h == "cp-node-2" && ip == "10.0.0.2"));
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_workers_when_on_workers_header() {
+        let mut component = create_test_component();
+        component.selected_item = NodeListItem::WorkersHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(result.is_some(), "WorkersHeader should return group nodes");
+
+        let (group_name, role, nodes) = result.unwrap();
+        assert_eq!(group_name, "Workers");
+        assert_eq!(role, "worker");
+        assert_eq!(nodes.len(), 2, "Should have 2 worker nodes");
+
+        // Verify node hostnames and IPs
+        assert!(nodes.iter().any(|(h, ip)| h == "worker-1" && ip == "10.0.0.3"));
+        assert!(nodes.iter().any(|(h, ip)| h == "worker-2" && ip == "10.0.0.4"));
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_none_when_no_controlplane_nodes() {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create a cluster with only workers (no etcd services)
+        let cluster = ClusterData {
+            name: "workers-only".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![make_version_info("worker-1")],
+            services: vec![make_node_services("worker-1", &["kubelet", "containerd"])],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([("worker-1".to_string(), "10.0.0.1".to_string())]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.selected_item = NodeListItem::ControlPlaneHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(
+            result.is_none(),
+            "ControlPlaneHeader with no controlplane nodes should return None"
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_none_when_no_worker_nodes() {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create a cluster with only control plane nodes
+        let cluster = ClusterData {
+            name: "cp-only".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![make_version_info("cp-node-1")],
+            services: vec![make_node_services("cp-node-1", &["etcd", "kubelet"])],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([("cp-node-1".to_string(), "10.0.0.1".to_string())]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.selected_item = NodeListItem::WorkersHeader(0);
+
+        let result = component.current_group_nodes();
+        assert!(
+            result.is_none(),
+            "WorkersHeader with no worker nodes should return None"
+        );
+    }
+
+    #[test]
+    fn test_current_group_nodes_returns_none_for_individual_nodes() {
+        let mut component = create_test_component();
+
+        // Test ControlPlaneNode
+        component.selected_item = NodeListItem::ControlPlaneNode(0, 0);
+        assert!(
+            component.current_group_nodes().is_none(),
+            "ControlPlaneNode should return None"
+        );
+
+        // Test WorkerNode
+        component.selected_item = NodeListItem::WorkerNode(0, 0);
+        assert!(
+            component.current_group_nodes().is_none(),
+            "WorkerNode should return None"
+        );
+    }
+
+    // ==========================================================================
+    // Tests for common_services_for_group()
+    // ==========================================================================
+
+    #[test]
+    fn test_common_services_for_group_returns_empty_for_empty_nodes() {
+        let component = create_test_component();
+
+        let result = component.common_services_for_group(&[]);
+        assert!(result.is_empty(), "Empty nodes should return empty services");
+    }
+
+    #[test]
+    fn test_common_services_for_group_returns_all_services_for_single_node() {
+        let component = create_test_component();
+
+        // Single control plane node
+        let nodes = vec![("cp-node-1".to_string(), "10.0.0.1".to_string())];
+
+        let result = component.common_services_for_group(&nodes);
+        assert_eq!(result.len(), 4, "Single node should return all its services");
+        assert!(result.contains(&"etcd".to_string()));
+        assert!(result.contains(&"kubelet".to_string()));
+        assert!(result.contains(&"apid".to_string()));
+        assert!(result.contains(&"containerd".to_string()));
+    }
+
+    #[test]
+    fn test_common_services_for_group_returns_intersection_for_multiple_nodes() {
+        let component = create_test_component();
+
+        // Control plane and worker nodes have different services
+        let nodes = vec![
+            ("cp-node-1".to_string(), "10.0.0.1".to_string()),
+            ("worker-1".to_string(), "10.0.0.3".to_string()),
+        ];
+
+        let result = component.common_services_for_group(&nodes);
+
+        // Common services: kubelet, apid, containerd (not etcd which is only on cp)
+        assert_eq!(
+            result.len(),
+            3,
+            "Should return only common services (intersection)"
+        );
+        assert!(result.contains(&"kubelet".to_string()));
+        assert!(result.contains(&"apid".to_string()));
+        assert!(result.contains(&"containerd".to_string()));
+        assert!(
+            !result.contains(&"etcd".to_string()),
+            "etcd should not be in common services"
+        );
+    }
+
+    #[test]
+    fn test_common_services_for_group_returns_empty_when_no_common_services() {
+        let mut component = ClusterComponent::new(None, None);
+
+        // Create nodes with completely different services
+        let cluster = ClusterData {
+            name: "test".to_string(),
+            client: None,
+            connected: true,
+            error: None,
+            versions: vec![make_version_info("node-a"), make_version_info("node-b")],
+            services: vec![
+                make_node_services("node-a", &["service-a", "service-b"]),
+                make_node_services("node-b", &["service-c", "service-d"]),
+            ],
+            memory: Vec::new(),
+            load_avg: Vec::new(),
+            cpu_info: Vec::new(),
+            etcd_members: Vec::new(),
+            discovery_members: Vec::new(),
+            etcd_summary: None,
+            node_ips: HashMap::from([
+                ("node-a".to_string(), "10.0.0.1".to_string()),
+                ("node-b".to_string(), "10.0.0.2".to_string()),
+            ]),
+            expanded: true,
+            controlplane_expanded: true,
+            workers_expanded: true,
+        };
+
+        component.clusters.push(cluster);
+        component.active_cluster = 0;
+
+        let nodes = vec![
+            ("node-a".to_string(), "10.0.0.1".to_string()),
+            ("node-b".to_string(), "10.0.0.2".to_string()),
+        ];
+
+        let result = component.common_services_for_group(&nodes);
+        assert!(
+            result.is_empty(),
+            "Nodes with no common services should return empty"
+        );
+    }
+
+    #[test]
+    fn test_common_services_for_group_sorts_results() {
+        let component = create_test_component();
+
+        // Use two control plane nodes that have the same services
+        let nodes = vec![
+            ("cp-node-1".to_string(), "10.0.0.1".to_string()),
+            ("cp-node-2".to_string(), "10.0.0.2".to_string()),
+        ];
+
+        let result = component.common_services_for_group(&nodes);
+
+        // Verify the result is sorted
+        let mut sorted = result.clone();
+        sorted.sort();
+        assert_eq!(result, sorted, "Results should be sorted alphabetically");
     }
 }
 

--- a/crates/talos-pilot-tui/src/components/diagnostics/mod.rs
+++ b/crates/talos-pilot-tui/src/components/diagnostics/mod.rs
@@ -195,7 +195,7 @@ impl DiagnosticsComponent {
             group_view_mode: GroupViewMode::default(),
             node_data: std::collections::HashMap::new(),
             selected_node_tab: 0,
-            node_role: node_role,
+            node_role,
         }
     }
 
@@ -1224,24 +1224,26 @@ impl Component for DiagnosticsComponent {
             }
             KeyCode::Char('[') => {
                 // Previous node tab (only in group view with ByNode mode)
-                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
-                    if self.selected_node_tab > 0 {
-                        self.selected_node_tab -= 1;
-                        // Reset selection when changing tabs
-                        self.selected_check = 0;
-                        self.table_state.select(Some(0));
-                    }
+                if self.is_group_view
+                    && self.group_view_mode == GroupViewMode::ByNode
+                    && self.selected_node_tab > 0
+                {
+                    self.selected_node_tab -= 1;
+                    // Reset selection when changing tabs
+                    self.selected_check = 0;
+                    self.table_state.select(Some(0));
                 }
             }
             KeyCode::Char(']') => {
                 // Next node tab (only in group view with ByNode mode)
-                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
-                    if self.selected_node_tab + 1 < self.nodes.len() {
-                        self.selected_node_tab += 1;
-                        // Reset selection when changing tabs
-                        self.selected_check = 0;
-                        self.table_state.select(Some(0));
-                    }
+                if self.is_group_view
+                    && self.group_view_mode == GroupViewMode::ByNode
+                    && self.selected_node_tab + 1 < self.nodes.len()
+                {
+                    self.selected_node_tab += 1;
+                    // Reset selection when changing tabs
+                    self.selected_check = 0;
+                    self.table_state.select(Some(0));
                 }
             }
             _ => {}
@@ -1283,7 +1285,10 @@ impl Component for DiagnosticsComponent {
         // Build header spans based on single node vs group view
         let header_spans = if self.is_group_view {
             let mut spans = vec![
-                Span::styled(" Diagnostics: ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    " Diagnostics: ",
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(&self.group_name, Style::default().fg(Color::Cyan)),
                 Span::styled(
                     format!(" ({} nodes)", self.nodes.len()),
@@ -1309,7 +1314,9 @@ impl Component for DiagnosticsComponent {
                     if i == self.selected_node_tab {
                         spans.push(Span::styled(
                             format!("[{}]", node_hostname),
-                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD),
                         ));
                     } else {
                         spans.push(Span::styled(
@@ -1323,12 +1330,10 @@ impl Component for DiagnosticsComponent {
             spans
         } else {
             // Single node header
-            vec![
-                Span::styled(
-                    format!(" Diagnostics: {} ({}) [{}] ", hostname, address, cni_label),
-                    Style::default().add_modifier(Modifier::BOLD),
-                ),
-            ]
+            vec![Span::styled(
+                format!(" Diagnostics: {} ({}) [{}] ", hostname, address, cni_label),
+                Style::default().add_modifier(Modifier::BOLD),
+            )]
         };
 
         // Header
@@ -1541,10 +1546,11 @@ mod tests {
         // Should have merged checks from both nodes (4 system checks total: 2 per node)
         assert_eq!(data.system_checks.len(), 4);
         // Check names should be prefixed with hostname
-        assert!(data
-            .system_checks
-            .iter()
-            .any(|c| c.name.starts_with("[node-1]") || c.name.starts_with("[node-2]")));
+        assert!(
+            data.system_checks
+                .iter()
+                .any(|c| c.name.starts_with("[node-1]") || c.name.starts_with("[node-2]"))
+        );
     }
 
     #[test]

--- a/crates/talos-pilot-tui/src/components/network.rs
+++ b/crates/talos-pilot-tui/src/components/network.rs
@@ -95,6 +95,16 @@ pub enum ConnSortBy {
     Port, // Sort by local port
 }
 
+/// View mode for group network
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GroupViewMode {
+    /// Interleaved network data from all nodes (default)
+    #[default]
+    Interleaved,
+    /// Network data organized by node (tabbed view)
+    ByNode,
+}
+
 /// Pending action requiring confirmation
 #[derive(Debug, Clone)]
 pub enum PendingAction {
@@ -207,6 +217,15 @@ pub struct NetworkData {
     pub kubespan_enabled: Option<bool>,
 }
 
+/// Per-node network data for group view
+#[derive(Debug, Clone, Default)]
+pub struct NodeNetworkData {
+    /// Node hostname
+    pub hostname: String,
+    /// Network data for this node
+    pub data: NetworkData,
+}
+
 /// Network stats component for viewing node network interfaces
 pub struct NetworkStatsComponent {
     /// Node hostname
@@ -274,6 +293,20 @@ pub struct NetworkStatsComponent {
     kubespan_selected: usize,
     /// KubeSpan table state
     kubespan_table_state: TableState,
+
+    // Group view fields
+    /// Whether this is a group view (multiple nodes)
+    is_group_view: bool,
+    /// Group name (e.g., "Control Plane", "Workers")
+    group_name: String,
+    /// Nodes in the group: Vec<(hostname, ip)>
+    nodes: Vec<(String, String)>,
+    /// Current view mode for group network
+    group_view_mode: GroupViewMode,
+    /// Per-node network data
+    node_data: HashMap<String, NodeNetworkData>,
+    /// Selected node tab index (for ByNode view mode)
+    selected_node_tab: usize,
 }
 
 impl Default for NetworkStatsComponent {
@@ -321,7 +354,120 @@ impl NetworkStatsComponent {
                 state.select(Some(0));
                 state
             },
+            // Group view fields (not used in single node mode)
+            is_group_view: false,
+            group_name: String::new(),
+            nodes: Vec::new(),
+            group_view_mode: GroupViewMode::default(),
+            node_data: HashMap::new(),
+            selected_node_tab: 0,
         }
+    }
+
+    /// Create a new network stats component for group view (multiple nodes)
+    /// - group_name: Name of the group (e.g., "Control Plane", "Workers")
+    /// - nodes: Vec of (hostname, ip) for each node
+    pub fn new_group(group_name: String, nodes: Vec<(String, String)>) -> Self {
+        let mut table_state = TableState::default();
+        table_state.select(Some(0));
+        let mut conn_table_state = TableState::default();
+        conn_table_state.select(Some(0));
+
+        Self {
+            hostname: group_name.clone(),
+            address: String::new(),
+            state: AsyncState::new(),
+            selected: 0,
+            table_state,
+            sort_by: SortBy::Traffic,
+            auto_refresh: true,
+            view_mode: ViewMode::Interfaces,
+            selected_interface: None,
+            filtered_connections: Vec::new(),
+            conn_selected: 0,
+            conn_table_state,
+            conn_sort_by: ConnSortBy::State,
+            listening_only: false,
+            show_all_connections: false,
+            conn_selection_start: None,
+            conn_viewport_height: 20,
+            pending_action: None,
+            status_message: None,
+            pending_restart_service: None,
+            show_output_pane: false,
+            command_output: None,
+            file_viewer: None,
+            capture: CaptureData::default(),
+            client: None,
+            kubespan_selected: 0,
+            kubespan_table_state: {
+                let mut state = TableState::default();
+                state.select(Some(0));
+                state
+            },
+            // Group view fields
+            is_group_view: true,
+            group_name,
+            nodes,
+            group_view_mode: GroupViewMode::default(),
+            node_data: HashMap::new(),
+            selected_node_tab: 0,
+        }
+    }
+
+    /// Add network data from a node (for group view)
+    pub fn add_node_network(&mut self, hostname: String, devices: Vec<NetDevStats>) {
+        if !self.is_group_view {
+            return;
+        }
+
+        // Store node data
+        let mut node_network = NodeNetworkData {
+            hostname: hostname.clone(),
+            data: NetworkData::default(),
+        };
+        node_network.data.devices = devices;
+
+        self.node_data.insert(hostname, node_network);
+
+        // Rebuild merged view
+        self.rebuild_group_data();
+    }
+
+    /// Rebuild merged network data for group view
+    fn rebuild_group_data(&mut self) {
+        if !self.is_group_view {
+            return;
+        }
+
+        // Merge all devices (prefixed with hostname for disambiguation)
+        let mut merged_devices = Vec::new();
+
+        for node_data in self.node_data.values() {
+            for device in &node_data.data.devices {
+                // Clone and prefix device name with hostname for clarity
+                let mut prefixed_device = device.clone();
+                prefixed_device.name = format!("{}:{}", node_data.hostname, device.name);
+                merged_devices.push(prefixed_device);
+            }
+        }
+
+        // Update the main state
+        if self.state.data().is_none() {
+            self.state.set_data(NetworkData::default());
+        }
+
+        if let Some(data) = self.state.data_mut() {
+            data.devices = merged_devices;
+
+            // Calculate totals
+            data.total_rx_rate = data.rates.values().map(|r| r.rx_bytes_per_sec).sum();
+            data.total_tx_rate = data.rates.values().map(|r| r.tx_bytes_per_sec).sum();
+            data.total_errors = data.devices.iter().map(|d| d.total_errors()).sum();
+            data.total_dropped = data.devices.iter().map(|d| d.total_dropped()).sum();
+        }
+
+        self.state.mark_loaded();
     }
 
     /// Get a reference to the loaded data
@@ -963,12 +1109,56 @@ impl NetworkStatsComponent {
             Span::raw("")
         };
 
-        let spans = vec![
+        // Build header spans based on single node vs group view
+        let mut spans = vec![
             Span::styled("Network: ", Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw(&self.hostname),
-            Span::styled(" (", Style::default().fg(Color::DarkGray)),
-            Span::raw(&self.address),
-            Span::styled(")", Style::default().fg(Color::DarkGray)),
+        ];
+
+        if self.is_group_view {
+            // Group view header
+            spans.push(Span::styled(&self.group_name, Style::default().fg(Color::Cyan)));
+            spans.push(Span::styled(
+                format!(" ({} nodes)", self.nodes.len()),
+                Style::default().fg(Color::DarkGray),
+            ));
+
+            // View mode indicator
+            let view_mode_label = match self.group_view_mode {
+                GroupViewMode::Interleaved => "[MERGED]",
+                GroupViewMode::ByNode => "[BY NODE]",
+            };
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(
+                view_mode_label,
+                Style::default().fg(Color::Green),
+            ));
+
+            // Node tabs for ByNode mode
+            if self.group_view_mode == GroupViewMode::ByNode && !self.nodes.is_empty() {
+                spans.push(Span::raw("  "));
+                for (i, (hostname, _)) in self.nodes.iter().enumerate() {
+                    if i == self.selected_node_tab {
+                        spans.push(Span::styled(
+                            format!("[{}]", hostname),
+                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                        ));
+                    } else {
+                        spans.push(Span::styled(
+                            format!(" {} ", hostname),
+                            Style::default().fg(Color::DarkGray),
+                        ));
+                    }
+                }
+            }
+        } else {
+            // Single node header
+            spans.push(Span::raw(&self.hostname));
+            spans.push(Span::styled(" (", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::raw(&self.address));
+            spans.push(Span::styled(")", Style::default().fg(Color::DarkGray)));
+        }
+
+        spans.extend(vec![
             Span::raw("  "),
             Span::styled(&device_count, Style::default().fg(Color::DarkGray)),
             Span::styled(auto_indicator, Style::default().fg(Color::Yellow)),
@@ -976,7 +1166,7 @@ impl NetworkStatsComponent {
             tab_ifaces,
             conns_indicator,
             tab_kubespan,
-        ];
+        ]);
 
         let header = Paragraph::new(Line::from(spans));
         frame.render_widget(header, area);
@@ -1188,6 +1378,19 @@ impl NetworkStatsComponent {
         }
     }
 
+    /// Get devices to display based on view mode (ByNode or Interleaved)
+    fn get_display_devices(&self) -> Option<Vec<&NetDevStats>> {
+        if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+            // ByNode mode: show devices from selected node only
+            let (hostname, _) = self.nodes.get(self.selected_node_tab)?;
+            let node_data = self.node_data.get(hostname)?;
+            Some(node_data.data.devices.iter().collect())
+        } else {
+            // Interleaved mode: use merged data
+            self.data().map(|d| d.devices.iter().collect())
+        }
+    }
+
     /// Draw the device table
     fn draw_device_table(&mut self, frame: &mut Frame, area: Rect) {
         // Build column headers with sort indicators
@@ -1215,19 +1418,33 @@ impl NetworkStatsComponent {
             .style(Style::default().add_modifier(Modifier::DIM))
             .bottom_margin(1);
 
-        // Get data for building rows
-        let Some(data) = self.data() else {
-            let table = Table::new(Vec::<Row>::new(), [Constraint::Fill(1)]).header(header);
-            frame.render_stateful_widget(table, area, &mut self.table_state);
-            return;
+        // Get devices based on view mode (ByNode or Interleaved)
+        let devices = match self.get_display_devices() {
+            Some(d) => d,
+            None => {
+                let table = Table::new(Vec::<Row>::new(), [Constraint::Fill(1)]).header(header);
+                frame.render_stateful_widget(table, area, &mut self.table_state);
+                return;
+            }
         };
 
-        let rows: Vec<Row> = data
-            .devices
+        // Get rates from the appropriate source
+        let rates = if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+            if let Some((hostname, _)) = self.nodes.get(self.selected_node_tab) {
+                self.node_data.get(hostname).map(|nd| &nd.data.rates)
+            } else {
+                None
+            }
+        } else {
+            self.data().map(|d| &d.rates)
+        };
+        let rates = rates.cloned().unwrap_or_default();
+
+        let rows: Vec<Row> = devices
             .iter()
             .enumerate()
             .map(|(idx, dev)| {
-                let rate = data.rates.get(&dev.name);
+                let rate = rates.get(&dev.name);
                 let rx_rate = rate
                     .map(|r| NetDevStats::format_rate(r.rx_bytes_per_sec))
                     .unwrap_or_else(|| "0 B/s".to_string());
@@ -1305,15 +1522,29 @@ impl NetworkStatsComponent {
 
     /// Draw the detail section for selected device
     fn draw_detail_section(&self, frame: &mut Frame, area: Rect) {
-        let Some(data) = self.data() else {
+        // Get devices and rates based on view mode
+        let (devices, rates) = if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+            // ByNode mode: get from selected node
+            let Some((hostname, _)) = self.nodes.get(self.selected_node_tab) else {
+                return;
+            };
+            let Some(node_data) = self.node_data.get(hostname) else {
+                return;
+            };
+            (&node_data.data.devices, &node_data.data.rates)
+        } else {
+            // Interleaved mode: use merged data
+            let Some(data) = self.data() else {
+                return;
+            };
+            (&data.devices, &data.rates)
+        };
+
+        let Some(dev) = devices.get(self.selected) else {
             return;
         };
 
-        let Some(dev) = data.devices.get(self.selected) else {
-            return;
-        };
-
-        let rate = data.rates.get(&dev.name);
+        let rate = rates.get(&dev.name);
         let rx_rate = rate
             .map(|r| NetDevStats::format_rate(r.rx_bytes_per_sec))
             .unwrap_or_else(|| "0 B/s".to_string());
@@ -1399,8 +1630,25 @@ impl NetworkStatsComponent {
         ];
 
         // Add connection summary line if we have connection data
-        if !data.connections.is_empty() {
-            let cc = &data.conn_counts;
+        // Get connection data from the appropriate source
+        let (connections, conn_counts) = if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+            if let Some((hostname, _)) = self.nodes.get(self.selected_node_tab) {
+                if let Some(node_data) = self.node_data.get(hostname) {
+                    (&node_data.data.connections, &node_data.data.conn_counts)
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            }
+        } else if let Some(data) = self.data() {
+            (&data.connections, &data.conn_counts)
+        } else {
+            return;
+        };
+
+        if !connections.is_empty() {
+            let cc = conn_counts;
             lines.push(Line::from(vec![
                 Span::styled(
                     "Connections: ",
@@ -1480,7 +1728,23 @@ impl NetworkStatsComponent {
             ("BPF:OFF", Color::Yellow)
         };
 
-        let spans = vec![
+        let mut spans = vec![];
+
+        // Add view mode toggle hint if in group view
+        if self.is_group_view {
+            spans.push(Span::styled("[v]", Style::default().fg(Color::Cyan)));
+            spans.push(Span::raw(" view  "));
+
+            // Add tab navigation hint if in ByNode mode
+            if self.group_view_mode == GroupViewMode::ByNode {
+                spans.push(Span::styled("[", Style::default().fg(Color::Cyan)));
+                spans.push(Span::styled("/", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled("]", Style::default().fg(Color::Cyan)));
+                spans.push(Span::raw(" tabs  "));
+            }
+        }
+
+        spans.extend(vec![
             Span::styled("[Tab]", Style::default().fg(Color::Cyan)),
             Span::raw(" views  "),
             Span::styled("[Enter]", Style::default().fg(Color::Cyan)),
@@ -1495,7 +1759,7 @@ impl NetworkStatsComponent {
             Span::raw(format!(" {}  ", auto_label)),
             Span::styled("[q]", Style::default().fg(Color::Cyan)),
             Span::raw(" back"),
-        ];
+        ]);
 
         let footer = Paragraph::new(Line::from(spans)).style(Style::default().fg(Color::DarkGray));
         frame.render_widget(footer, area);
@@ -2378,6 +2642,43 @@ impl NetworkStatsComponent {
             // Toggle BPF filter for packet capture
             KeyCode::Char('f') => {
                 self.toggle_bpf_filter();
+                Ok(None)
+            }
+            KeyCode::Char('v') => {
+                // Toggle view mode (only in group view)
+                if self.is_group_view {
+                    self.group_view_mode = match self.group_view_mode {
+                        GroupViewMode::Interleaved => GroupViewMode::ByNode,
+                        GroupViewMode::ByNode => GroupViewMode::Interleaved,
+                    };
+                    // Reset selection when changing view mode
+                    self.selected = 0;
+                    self.table_state.select(Some(0));
+                }
+                Ok(None)
+            }
+            KeyCode::Char('[') => {
+                // Previous node tab (only in group view with ByNode mode)
+                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+                    if self.selected_node_tab > 0 {
+                        self.selected_node_tab -= 1;
+                        // Reset selection when changing tabs
+                        self.selected = 0;
+                        self.table_state.select(Some(0));
+                    }
+                }
+                Ok(None)
+            }
+            KeyCode::Char(']') => {
+                // Next node tab (only in group view with ByNode mode)
+                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+                    if self.selected_node_tab + 1 < self.nodes.len() {
+                        self.selected_node_tab += 1;
+                        // Reset selection when changing tabs
+                        self.selected = 0;
+                        self.table_state.select(Some(0));
+                    }
+                }
                 Ok(None)
             }
             _ => Ok(None),
@@ -3694,5 +3995,161 @@ impl NetworkStatsComponent {
             let bar = Paragraph::new(status).style(Style::default().bg(Color::Black));
             frame.render_widget(bar, area);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a test NetDevStats
+    fn make_device(name: &str) -> NetDevStats {
+        NetDevStats {
+            name: name.to_string(),
+            rx_bytes: 1000,
+            rx_packets: 10,
+            rx_errors: 0,
+            rx_dropped: 0,
+            tx_bytes: 500,
+            tx_packets: 5,
+            tx_errors: 0,
+            tx_dropped: 0,
+        }
+    }
+
+    /// Create a NetworkStatsComponent for single node view
+    fn create_single_node_component() -> NetworkStatsComponent {
+        let mut component =
+            NetworkStatsComponent::new("test-node".to_string(), "10.0.0.1".to_string());
+
+        // Set up data with devices
+        let mut data = NetworkData::default();
+        data.devices = vec![make_device("eth0"), make_device("lo"), make_device("cni0")];
+
+        component.state.set_data(data);
+        component
+    }
+
+    /// Create a NetworkStatsComponent for group view
+    fn create_group_component() -> NetworkStatsComponent {
+        let nodes = vec![
+            ("node-1".to_string(), "10.0.0.1".to_string()),
+            ("node-2".to_string(), "10.0.0.2".to_string()),
+        ];
+        let mut component = NetworkStatsComponent::new_group("Control Plane".to_string(), nodes);
+
+        // Add node data
+        component.add_node_network(
+            "node-1".to_string(),
+            vec![make_device("eth0"), make_device("lo")],
+        );
+        component.add_node_network(
+            "node-2".to_string(),
+            vec![make_device("eth0"), make_device("cni0")],
+        );
+
+        component
+    }
+
+    // ==========================================================================
+    // Tests for get_display_devices()
+    // ==========================================================================
+
+    #[test]
+    fn test_get_display_devices_single_node_returns_merged_data() {
+        let component = create_single_node_component();
+
+        // Single node view should return the merged data regardless of view mode
+        let result = component.get_display_devices();
+        assert!(result.is_some());
+
+        let devices = result.unwrap();
+        assert_eq!(devices.len(), 3);
+        assert!(devices.iter().any(|d| d.name == "eth0"));
+        assert!(devices.iter().any(|d| d.name == "lo"));
+        assert!(devices.iter().any(|d| d.name == "cni0"));
+    }
+
+    #[test]
+    fn test_get_display_devices_group_interleaved_returns_merged_data() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::Interleaved;
+
+        let result = component.get_display_devices();
+        assert!(result.is_some());
+
+        let devices = result.unwrap();
+        // Should have merged devices from both nodes (prefixed with hostname)
+        assert_eq!(devices.len(), 4);
+        // Device names should be prefixed with hostname
+        assert!(devices
+            .iter()
+            .any(|d| d.name.contains("node-1:") || d.name.contains("node-2:")));
+    }
+
+    #[test]
+    fn test_get_display_devices_group_bynode_returns_selected_node_data() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 0; // Select first node
+
+        let result = component.get_display_devices();
+        assert!(result.is_some());
+
+        let devices = result.unwrap();
+        // Should only have devices from node-1
+        assert_eq!(devices.len(), 2);
+        assert!(devices.iter().any(|d| d.name == "eth0"));
+        assert!(devices.iter().any(|d| d.name == "lo"));
+        assert!(!devices.iter().any(|d| d.name == "cni0"));
+    }
+
+    #[test]
+    fn test_get_display_devices_group_bynode_second_node() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 1; // Select second node
+
+        let result = component.get_display_devices();
+        assert!(result.is_some());
+
+        let devices = result.unwrap();
+        // Should only have devices from node-2
+        assert_eq!(devices.len(), 2);
+        assert!(devices.iter().any(|d| d.name == "eth0"));
+        assert!(devices.iter().any(|d| d.name == "cni0"));
+        assert!(!devices.iter().any(|d| d.name == "lo"));
+    }
+
+    #[test]
+    fn test_get_display_devices_returns_none_when_tab_out_of_bounds() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 99; // Invalid tab index
+
+        let result = component.get_display_devices();
+        assert!(result.is_none(), "Should return None for invalid tab index");
+    }
+
+    #[test]
+    fn test_get_display_devices_group_bynode_with_no_data_for_node() {
+        let nodes = vec![
+            ("node-1".to_string(), "10.0.0.1".to_string()),
+            ("node-2".to_string(), "10.0.0.2".to_string()),
+        ];
+        let mut component = NetworkStatsComponent::new_group("Control Plane".to_string(), nodes);
+        component.group_view_mode = GroupViewMode::ByNode;
+
+        // Only add data for node-1
+        component.add_node_network("node-1".to_string(), vec![make_device("eth0")]);
+
+        // Select node-2 which has no data
+        component.selected_node_tab = 1;
+
+        let result = component.get_display_devices();
+        assert!(
+            result.is_none(),
+            "Should return None when selected node has no data"
+        );
     }
 }

--- a/crates/talos-pilot-tui/src/components/processes.rs
+++ b/crates/talos-pilot-tui/src/components/processes.rs
@@ -710,10 +710,11 @@ impl ProcessesComponent {
         }
 
         // Reset selection if needed
-        if let Some(data) = self.data() {
-            if !data.display_entries.is_empty() && self.selected >= data.display_entries.len() {
-                self.selected = 0;
-            }
+        if let Some(data) = self.data()
+            && !data.display_entries.is_empty()
+            && self.selected >= data.display_entries.len()
+        {
+            self.selected = 0;
         }
         self.table_state.select(Some(self.selected));
 
@@ -1049,13 +1050,17 @@ impl ProcessesComponent {
         let proc_count = format!("{} procs", data.display_entries.len());
 
         // Build header based on single node vs group view
-        let mut spans = vec![
-            Span::styled("Processes: ", Style::default().add_modifier(Modifier::BOLD)),
-        ];
+        let mut spans = vec![Span::styled(
+            "Processes: ",
+            Style::default().add_modifier(Modifier::BOLD),
+        )];
 
         if self.is_group_view {
             // Group view header
-            spans.push(Span::styled(&self.group_name, Style::default().fg(Color::Cyan)));
+            spans.push(Span::styled(
+                &self.group_name,
+                Style::default().fg(Color::Cyan),
+            ));
             spans.push(Span::styled(
                 format!(" ({} nodes)", self.nodes.len()),
                 Style::default().fg(Color::DarkGray),
@@ -1079,7 +1084,9 @@ impl ProcessesComponent {
                     if i == self.selected_node_tab {
                         spans.push(Span::styled(
                             format!("[{}]", hostname),
-                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD),
                         ));
                     } else {
                         spans.push(Span::styled(
@@ -1113,7 +1120,10 @@ impl ProcessesComponent {
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled("[", Style::default().fg(Color::DarkGray)));
                 if !cpu_info.is_empty() {
-                    spans.push(Span::styled(cpu_info.clone(), Style::default().fg(Color::Cyan)));
+                    spans.push(Span::styled(
+                        cpu_info.clone(),
+                        Style::default().fg(Color::Cyan),
+                    ));
                 }
                 if !cpu_info.is_empty() && !mem_info.is_empty() {
                     spans.push(Span::styled(" | ", Style::default().fg(Color::DarkGray)));
@@ -1361,21 +1371,22 @@ impl ProcessesComponent {
         let max_cmd_len = area.width.saturating_sub(45) as usize;
 
         // Get effective processes based on view mode
-        let (processes, cpu_percentages) = if self.is_group_view && self.view_mode == GroupViewMode::ByNode {
-            // ByNode mode: show processes from selected node only
-            if let Some((hostname, _)) = self.nodes.get(self.selected_node_tab) {
-                if let Some(node_data) = self.node_data.get(hostname) {
-                    (&node_data.processes, &node_data.cpu_percentages)
+        let (processes, cpu_percentages) =
+            if self.is_group_view && self.view_mode == GroupViewMode::ByNode {
+                // ByNode mode: show processes from selected node only
+                if let Some((hostname, _)) = self.nodes.get(self.selected_node_tab) {
+                    if let Some(node_data) = self.node_data.get(hostname) {
+                        (&node_data.processes, &node_data.cpu_percentages)
+                    } else {
+                        return None;
+                    }
                 } else {
                     return None;
                 }
             } else {
-                return None;
-            }
-        } else {
-            // Interleaved mode or single node: use merged data
-            (&data.processes, &data.cpu_percentages)
-        };
+                // Interleaved mode or single node: use merged data
+                (&data.processes, &data.cpu_percentages)
+            };
 
         let max_mem = processes
             .iter()
@@ -1717,14 +1728,23 @@ impl ProcessesComponent {
 
         // Add view mode toggle hint if in group view
         if self.is_group_view {
-            spans.push(Span::styled("[v]", Style::default().add_modifier(Modifier::BOLD)));
+            spans.push(Span::styled(
+                "[v]",
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
             spans.push(Span::raw(" view "));
 
             // Add tab navigation hint if in ByNode mode
             if self.view_mode == GroupViewMode::ByNode {
-                spans.push(Span::styled("[", Style::default().add_modifier(Modifier::BOLD)));
+                spans.push(Span::styled(
+                    "[",
+                    Style::default().add_modifier(Modifier::BOLD),
+                ));
                 spans.push(Span::styled("/", Style::default().fg(Color::DarkGray)));
-                spans.push(Span::styled("]", Style::default().add_modifier(Modifier::BOLD)));
+                spans.push(Span::styled(
+                    "]",
+                    Style::default().add_modifier(Modifier::BOLD),
+                ));
                 spans.push(Span::raw(" tabs "));
             }
         }
@@ -1982,25 +2002,27 @@ impl ProcessesComponent {
             }
             KeyCode::Char('[') => {
                 // Previous node tab (only in group view with ByNode mode)
-                if self.is_group_view && self.view_mode == GroupViewMode::ByNode {
-                    if self.selected_node_tab > 0 {
-                        self.selected_node_tab -= 1;
-                        // Reset selection when changing tabs
-                        self.selected = 0;
-                        self.table_state.select(Some(0));
-                    }
+                if self.is_group_view
+                    && self.view_mode == GroupViewMode::ByNode
+                    && self.selected_node_tab > 0
+                {
+                    self.selected_node_tab -= 1;
+                    // Reset selection when changing tabs
+                    self.selected = 0;
+                    self.table_state.select(Some(0));
                 }
                 Ok(None)
             }
             KeyCode::Char(']') => {
                 // Next node tab (only in group view with ByNode mode)
-                if self.is_group_view && self.view_mode == GroupViewMode::ByNode {
-                    if self.selected_node_tab + 1 < self.nodes.len() {
-                        self.selected_node_tab += 1;
-                        // Reset selection when changing tabs
-                        self.selected = 0;
-                        self.table_state.select(Some(0));
-                    }
+                if self.is_group_view
+                    && self.view_mode == GroupViewMode::ByNode
+                    && self.selected_node_tab + 1 < self.nodes.len()
+                {
+                    self.selected_node_tab += 1;
+                    // Reset selection when changing tabs
+                    self.selected = 0;
+                    self.table_state.select(Some(0));
                 }
                 Ok(None)
             }

--- a/crates/talos-pilot-tui/src/components/storage.rs
+++ b/crates/talos-pilot-tui/src/components/storage.rs
@@ -212,7 +212,12 @@ impl StorageComponent {
     }
 
     /// Add storage data from a node (for group view)
-    pub fn add_node_storage(&mut self, hostname: String, disks: Vec<DiskInfo>, volumes: Vec<VolumeStatus>) {
+    pub fn add_node_storage(
+        &mut self,
+        hostname: String,
+        disks: Vec<DiskInfo>,
+        volumes: Vec<VolumeStatus>,
+    ) {
         if !self.is_group_view {
             return;
         }
@@ -353,7 +358,9 @@ impl StorageComponent {
             match get_disks_for_node(&context, node_ip, config_path.as_deref()).await {
                 Ok(disks) => {
                     // Fetch volumes
-                    match get_volume_status_for_node(&context, node_ip, config_path.as_deref()).await {
+                    match get_volume_status_for_node(&context, node_ip, config_path.as_deref())
+                        .await
+                    {
                         Ok(volumes) => {
                             self.add_node_storage(hostname.clone(), disks, volumes);
                         }
@@ -749,7 +756,10 @@ impl StorageComponent {
 
         if self.is_group_view {
             // Group view header
-            line_spans.push(Span::styled(&self.group_name, Style::default().fg(Color::Cyan)));
+            line_spans.push(Span::styled(
+                &self.group_name,
+                Style::default().fg(Color::Cyan),
+            ));
             line_spans.push(Span::styled(
                 format!(" ({} nodes)", self.nodes.len()),
                 Style::default().fg(Color::DarkGray),
@@ -773,7 +783,9 @@ impl StorageComponent {
                     if i == self.selected_node_tab {
                         line_spans.push(Span::styled(
                             format!("[{}]", hostname),
-                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD),
                         ));
                     } else {
                         line_spans.push(Span::styled(
@@ -830,24 +842,26 @@ impl Component for StorageComponent {
             }
             KeyCode::Char('[') => {
                 // Previous node tab (only in group view with ByNode mode)
-                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
-                    if self.selected_node_tab > 0 {
-                        self.selected_node_tab -= 1;
-                        // Reset selection when changing tabs
-                        self.disk_table_state.select(Some(0));
-                        self.volume_table_state.select(Some(0));
-                    }
+                if self.is_group_view
+                    && self.group_view_mode == GroupViewMode::ByNode
+                    && self.selected_node_tab > 0
+                {
+                    self.selected_node_tab -= 1;
+                    // Reset selection when changing tabs
+                    self.disk_table_state.select(Some(0));
+                    self.volume_table_state.select(Some(0));
                 }
             }
             KeyCode::Char(']') => {
                 // Next node tab (only in group view with ByNode mode)
-                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
-                    if self.selected_node_tab + 1 < self.nodes.len() {
-                        self.selected_node_tab += 1;
-                        // Reset selection when changing tabs
-                        self.disk_table_state.select(Some(0));
-                        self.volume_table_state.select(Some(0));
-                    }
+                if self.is_group_view
+                    && self.group_view_mode == GroupViewMode::ByNode
+                    && self.selected_node_tab + 1 < self.nodes.len()
+                {
+                    self.selected_node_tab += 1;
+                    // Reset selection when changing tabs
+                    self.disk_table_state.select(Some(0));
+                    self.volume_table_state.select(Some(0));
                 }
             }
             _ => {}
@@ -970,17 +984,15 @@ mod tests {
 
     /// Create a StorageComponent for single node view
     fn create_single_node_component() -> StorageComponent {
-        let mut component = StorageComponent::new(
-            "test-node".to_string(),
-            "10.0.0.1".to_string(),
-            None,
-            None,
-        );
+        let mut component =
+            StorageComponent::new("test-node".to_string(), "10.0.0.1".to_string(), None, None);
 
         // Set up data
-        let mut data = StorageData::default();
-        data.disks = vec![make_disk("sda"), make_disk("sdb")];
-        data.volumes = vec![make_volume("STATE"), make_volume("EPHEMERAL")];
+        let data = StorageData {
+            disks: vec![make_disk("sda"), make_disk("sdb")],
+            volumes: vec![make_volume("STATE"), make_volume("EPHEMERAL")],
+            ..Default::default()
+        };
 
         component.state.set_data(data);
         component
@@ -1038,9 +1050,11 @@ mod tests {
         // Should have merged disks from both nodes (3 total)
         assert_eq!(disks.len(), 3);
         // Dev paths should be prefixed with hostname
-        assert!(disks
-            .iter()
-            .any(|d| d.dev_path.contains("node-1:") || d.dev_path.contains("node-2:")));
+        assert!(
+            disks
+                .iter()
+                .any(|d| d.dev_path.contains("node-1:") || d.dev_path.contains("node-2:"))
+        );
     }
 
     #[test]
@@ -1115,9 +1129,11 @@ mod tests {
         // Should have merged volumes from both nodes (3 total)
         assert_eq!(volumes.len(), 3);
         // IDs should be prefixed with hostname
-        assert!(volumes
-            .iter()
-            .any(|v| v.id.contains("node-1:") || v.id.contains("node-2:")));
+        assert!(
+            volumes
+                .iter()
+                .any(|v| v.id.contains("node-1:") || v.id.contains("node-2:"))
+        );
     }
 
     #[test]

--- a/crates/talos-pilot-tui/src/components/storage.rs
+++ b/crates/talos-pilot-tui/src/components/storage.rs
@@ -46,6 +46,27 @@ impl StorageViewMode {
     }
 }
 
+/// View mode for group storage
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GroupViewMode {
+    /// Interleaved storage data from all nodes (default)
+    #[default]
+    Interleaved,
+    /// Storage data organized by node (tabbed view)
+    ByNode,
+}
+
+/// Per-node storage data for group view
+#[derive(Debug, Clone, Default)]
+pub struct NodeStorageData {
+    /// Node hostname
+    pub hostname: String,
+    /// Disks from this node
+    pub disks: Vec<DiskInfo>,
+    /// Volumes from this node
+    pub volumes: Vec<VolumeStatus>,
+}
+
 /// Loaded storage data (wrapped by AsyncState)
 #[derive(Debug, Clone, Default)]
 pub struct StorageData {
@@ -88,6 +109,20 @@ pub struct StorageComponent {
 
     /// Config path for authentication
     config_path: Option<String>,
+
+    // Group view fields
+    /// Whether this is a group view (multiple nodes)
+    is_group_view: bool,
+    /// Group name (e.g., "Control Plane", "Workers")
+    group_name: String,
+    /// Nodes in the group: Vec<(hostname, ip)>
+    nodes: Vec<(String, String)>,
+    /// Current view mode for group storage
+    group_view_mode: GroupViewMode,
+    /// Per-node storage data
+    node_data: std::collections::HashMap<String, NodeStorageData>,
+    /// Selected node tab index (for ByNode view mode)
+    selected_node_tab: usize,
 }
 
 impl Default for StorageComponent {
@@ -131,7 +166,96 @@ impl StorageComponent {
             node_address,
             context,
             config_path,
+            // Group view fields (not used in single node mode)
+            is_group_view: false,
+            group_name: String::new(),
+            nodes: Vec::new(),
+            group_view_mode: GroupViewMode::default(),
+            node_data: std::collections::HashMap::new(),
+            selected_node_tab: 0,
         }
+    }
+
+    /// Create a new storage component for group view (multiple nodes)
+    /// - group_name: Name of the group (e.g., "Control Plane", "Workers")
+    /// - nodes: Vec of (hostname, ip) for each node
+    pub fn new_group(group_name: String, nodes: Vec<(String, String)>) -> Self {
+        let mut disk_table_state = TableState::default();
+        disk_table_state.select(Some(0));
+        let mut volume_table_state = TableState::default();
+        volume_table_state.select(Some(0));
+
+        let initial_data = StorageData {
+            hostname: group_name.clone(),
+            address: String::new(),
+            ..Default::default()
+        };
+
+        Self {
+            state: AsyncState::with_data(initial_data),
+            view_mode: StorageViewMode::Disks,
+            disk_table_state,
+            volume_table_state,
+            auto_refresh: true,
+            client: None,
+            node_address: None,
+            context: None,
+            config_path: None,
+            // Group view fields
+            is_group_view: true,
+            group_name,
+            nodes,
+            group_view_mode: GroupViewMode::default(),
+            node_data: std::collections::HashMap::new(),
+            selected_node_tab: 0,
+        }
+    }
+
+    /// Add storage data from a node (for group view)
+    pub fn add_node_storage(&mut self, hostname: String, disks: Vec<DiskInfo>, volumes: Vec<VolumeStatus>) {
+        if !self.is_group_view {
+            return;
+        }
+
+        // Store node data
+        let node_storage = NodeStorageData {
+            hostname: hostname.clone(),
+            disks,
+            volumes,
+        };
+        self.node_data.insert(hostname, node_storage);
+
+        // Rebuild merged view
+        self.rebuild_group_data();
+    }
+
+    /// Rebuild merged storage data for group view
+    fn rebuild_group_data(&mut self) {
+        if !self.is_group_view {
+            return;
+        }
+
+        // Get or create data
+        let mut data = self.state.take_data().unwrap_or_default();
+
+        // Merge all disks and volumes (prefixed with hostname)
+        data.disks.clear();
+        data.volumes.clear();
+
+        for node_data in self.node_data.values() {
+            for disk in &node_data.disks {
+                let mut prefixed_disk = disk.clone();
+                prefixed_disk.dev_path = format!("{}:{}", node_data.hostname, disk.dev_path);
+                data.disks.push(prefixed_disk);
+            }
+            for volume in &node_data.volumes {
+                let mut prefixed_volume = volume.clone();
+                prefixed_volume.id = format!("{}:{}", node_data.hostname, volume.id);
+                data.volumes.push(prefixed_volume);
+            }
+        }
+
+        self.state.set_data(data);
     }
 
     /// Set the client for API calls
@@ -255,6 +379,32 @@ impl StorageComponent {
         }
     }
 
+    /// Get disks to display based on view mode (ByNode or Interleaved)
+    fn get_display_disks(&self) -> Option<Vec<&DiskInfo>> {
+        if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+            // ByNode mode: show disks from selected node only
+            let (hostname, _) = self.nodes.get(self.selected_node_tab)?;
+            let node_data = self.node_data.get(hostname)?;
+            Some(node_data.disks.iter().collect())
+        } else {
+            // Interleaved mode: use merged data
+            self.data().map(|d| d.disks.iter().collect())
+        }
+    }
+
+    /// Get volumes to display based on view mode (ByNode or Interleaved)
+    fn get_display_volumes(&self) -> Option<Vec<&VolumeStatus>> {
+        if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+            // ByNode mode: show volumes from selected node only
+            let (hostname, _) = self.nodes.get(self.selected_node_tab)?;
+            let node_data = self.node_data.get(hostname)?;
+            Some(node_data.volumes.iter().collect())
+        } else {
+            // Interleaved mode: use merged data
+            self.data().map(|d| d.volumes.iter().collect())
+        }
+    }
+
     /// Draw the disks view
     fn draw_disks_view(&mut self, frame: &mut Frame, area: Rect) {
         let chunks = Layout::vertical([
@@ -273,8 +423,8 @@ impl StorageComponent {
         ])
         .height(1);
 
-        let rows: Vec<Row> = if let Some(data) = self.data() {
-            data.disks
+        let rows: Vec<Row> = if let Some(disks) = self.get_display_disks() {
+            disks
                 .iter()
                 .map(|disk| {
                     let disk_type = if disk.cdrom {
@@ -337,8 +487,8 @@ impl StorageComponent {
             .title(" Details ")
             .title_style(Style::default().fg(Color::Yellow));
 
-        let content = if let Some(data) = self.data() {
-            if let Some(disk) = data.disks.get(self.selected_disk_index()) {
+        let content = if let Some(disks) = self.get_display_disks() {
+            if let Some(disk) = disks.get(self.selected_disk_index()) {
                 let mut lines = vec![
                     Line::from(vec![
                         Span::styled("Device: ", Style::default().fg(Color::Gray)),
@@ -409,8 +559,8 @@ impl StorageComponent {
         ])
         .height(1);
 
-        let rows: Vec<Row> = if let Some(data) = self.data() {
-            data.volumes
+        let rows: Vec<Row> = if let Some(volumes) = self.get_display_volumes() {
+            volumes
                 .iter()
                 .map(|vol| {
                     let phase_color = match vol.phase.as_str() {
@@ -475,8 +625,8 @@ impl StorageComponent {
             .title(" Details ")
             .title_style(Style::default().fg(Color::Yellow));
 
-        let content = if let Some(data) = self.data() {
-            if let Some(vol) = data.volumes.get(self.selected_volume_index()) {
+        let content = if let Some(volumes) = self.get_display_volumes() {
+            if let Some(vol) = volumes.get(self.selected_volume_index()) {
                 vec![
                     Line::from(vec![
                         Span::styled("Volume: ", Style::default().fg(Color::Gray)),
@@ -534,14 +684,53 @@ impl StorageComponent {
             })
             .collect();
 
-        let hostname = self.data().map(|d| d.hostname.clone()).unwrap_or_default();
-
         let mut line_spans = tab_spans;
         line_spans.push(Span::raw("  "));
-        line_spans.push(Span::styled(
-            format!("Node: {}", hostname),
-            Style::default().fg(Color::DarkGray),
-        ));
+
+        if self.is_group_view {
+            // Group view header
+            line_spans.push(Span::styled(&self.group_name, Style::default().fg(Color::Cyan)));
+            line_spans.push(Span::styled(
+                format!(" ({} nodes)", self.nodes.len()),
+                Style::default().fg(Color::DarkGray),
+            ));
+
+            // View mode indicator
+            let view_mode_label = match self.group_view_mode {
+                GroupViewMode::Interleaved => "[MERGED]",
+                GroupViewMode::ByNode => "[BY NODE]",
+            };
+            line_spans.push(Span::raw("  "));
+            line_spans.push(Span::styled(
+                view_mode_label,
+                Style::default().fg(Color::Green),
+            ));
+
+            // Node tabs for ByNode mode
+            if self.group_view_mode == GroupViewMode::ByNode && !self.nodes.is_empty() {
+                line_spans.push(Span::raw("  "));
+                for (i, (hostname, _)) in self.nodes.iter().enumerate() {
+                    if i == self.selected_node_tab {
+                        line_spans.push(Span::styled(
+                            format!("[{}]", hostname),
+                            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                        ));
+                    } else {
+                        line_spans.push(Span::styled(
+                            format!(" {} ", hostname),
+                            Style::default().fg(Color::DarkGray),
+                        ));
+                    }
+                }
+            }
+        } else {
+            // Single node header
+            let hostname = self.data().map(|d| d.hostname.clone()).unwrap_or_default();
+            line_spans.push(Span::styled(
+                format!("Node: {}", hostname),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
 
         let tabs_line = Line::from(line_spans);
         let paragraph = Paragraph::new(tabs_line);
@@ -566,6 +755,40 @@ impl Component for StorageComponent {
             }
             KeyCode::Char('r') => {
                 return Ok(Some(Action::Refresh));
+            }
+            KeyCode::Char('v') => {
+                // Toggle view mode (only in group view)
+                if self.is_group_view {
+                    self.group_view_mode = match self.group_view_mode {
+                        GroupViewMode::Interleaved => GroupViewMode::ByNode,
+                        GroupViewMode::ByNode => GroupViewMode::Interleaved,
+                    };
+                    // Reset selection when changing view mode
+                    self.disk_table_state.select(Some(0));
+                    self.volume_table_state.select(Some(0));
+                }
+            }
+            KeyCode::Char('[') => {
+                // Previous node tab (only in group view with ByNode mode)
+                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+                    if self.selected_node_tab > 0 {
+                        self.selected_node_tab -= 1;
+                        // Reset selection when changing tabs
+                        self.disk_table_state.select(Some(0));
+                        self.volume_table_state.select(Some(0));
+                    }
+                }
+            }
+            KeyCode::Char(']') => {
+                // Next node tab (only in group view with ByNode mode)
+                if self.is_group_view && self.group_view_mode == GroupViewMode::ByNode {
+                    if self.selected_node_tab + 1 < self.nodes.len() {
+                        self.selected_node_tab += 1;
+                        // Reset selection when changing tabs
+                        self.disk_table_state.select(Some(0));
+                        self.volume_table_state.select(Some(0));
+                    }
+                }
             }
             _ => {}
         }
@@ -616,7 +839,23 @@ impl Component for StorageComponent {
         }
 
         // Draw help line
-        let help = Line::from(vec![
+        let mut help_spans = vec![];
+
+        // Add view mode toggle hint if in group view
+        if self.is_group_view {
+            help_spans.push(Span::styled("v", Style::default().fg(Color::Cyan)));
+            help_spans.push(Span::raw(" view  "));
+
+            // Add tab navigation hint if in ByNode mode
+            if self.group_view_mode == GroupViewMode::ByNode {
+                help_spans.push(Span::styled("[", Style::default().fg(Color::Cyan)));
+                help_spans.push(Span::styled("/", Style::default().fg(Color::DarkGray)));
+                help_spans.push(Span::styled("]", Style::default().fg(Color::Cyan)));
+                help_spans.push(Span::raw(" tabs  "));
+            }
+        }
+
+        help_spans.extend(vec![
             Span::styled(" Tab", Style::default().fg(Color::Cyan)),
             Span::raw(" switch view  "),
             Span::styled("↑/↓", Style::default().fg(Color::Cyan)),
@@ -626,9 +865,271 @@ impl Component for StorageComponent {
             Span::styled("Esc", Style::default().fg(Color::Cyan)),
             Span::raw(" back"),
         ]);
+
+        let help = Line::from(help_spans);
         let help_paragraph = Paragraph::new(help).style(Style::default().fg(Color::DarkGray));
         frame.render_widget(help_paragraph, chunks[2]);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a test DiskInfo
+    fn make_disk(id: &str) -> DiskInfo {
+        DiskInfo {
+            id: id.to_string(),
+            dev_path: format!("/dev/{}", id),
+            size: 500_000_000_000,
+            size_pretty: "500 GB".to_string(),
+            model: Some("Test Disk".to_string()),
+            serial: Some("ABC123".to_string()),
+            transport: Some("sata".to_string()),
+            rotational: false,
+            readonly: false,
+            cdrom: false,
+            wwid: None,
+            bus_path: None,
+        }
+    }
+
+    /// Create a test VolumeStatus
+    fn make_volume(id: &str) -> VolumeStatus {
+        VolumeStatus {
+            id: id.to_string(),
+            encryption_provider: None,
+            phase: "ready".to_string(),
+            size: "10 GB".to_string(),
+            filesystem: Some("xfs".to_string()),
+            mount_location: Some(format!("/var/{}", id)),
+        }
+    }
+
+    /// Create a StorageComponent for single node view
+    fn create_single_node_component() -> StorageComponent {
+        let mut component = StorageComponent::new(
+            "test-node".to_string(),
+            "10.0.0.1".to_string(),
+            None,
+            None,
+        );
+
+        // Set up data
+        let mut data = StorageData::default();
+        data.disks = vec![make_disk("sda"), make_disk("sdb")];
+        data.volumes = vec![make_volume("STATE"), make_volume("EPHEMERAL")];
+
+        component.state.set_data(data);
+        component
+    }
+
+    /// Create a StorageComponent for group view
+    fn create_group_component() -> StorageComponent {
+        let nodes = vec![
+            ("node-1".to_string(), "10.0.0.1".to_string()),
+            ("node-2".to_string(), "10.0.0.2".to_string()),
+        ];
+        let mut component = StorageComponent::new_group("Control Plane".to_string(), nodes);
+
+        // Add node data
+        component.add_node_storage(
+            "node-1".to_string(),
+            vec![make_disk("sda"), make_disk("sdb")],
+            vec![make_volume("STATE")],
+        );
+        component.add_node_storage(
+            "node-2".to_string(),
+            vec![make_disk("nvme0n1")],
+            vec![make_volume("STATE"), make_volume("EPHEMERAL")],
+        );
+
+        component
+    }
+
+    // ==========================================================================
+    // Tests for get_display_disks()
+    // ==========================================================================
+
+    #[test]
+    fn test_get_display_disks_single_node_returns_all_disks() {
+        let component = create_single_node_component();
+
+        let result = component.get_display_disks();
+        assert!(result.is_some());
+
+        let disks = result.unwrap();
+        assert_eq!(disks.len(), 2);
+        assert!(disks.iter().any(|d| d.id == "sda"));
+        assert!(disks.iter().any(|d| d.id == "sdb"));
+    }
+
+    #[test]
+    fn test_get_display_disks_group_interleaved_returns_merged_data() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::Interleaved;
+
+        let result = component.get_display_disks();
+        assert!(result.is_some());
+
+        let disks = result.unwrap();
+        // Should have merged disks from both nodes (3 total)
+        assert_eq!(disks.len(), 3);
+        // Dev paths should be prefixed with hostname
+        assert!(disks
+            .iter()
+            .any(|d| d.dev_path.contains("node-1:") || d.dev_path.contains("node-2:")));
+    }
+
+    #[test]
+    fn test_get_display_disks_group_bynode_returns_selected_node_data() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 0; // Select first node
+
+        let result = component.get_display_disks();
+        assert!(result.is_some());
+
+        let disks = result.unwrap();
+        // Should only have disks from node-1
+        assert_eq!(disks.len(), 2);
+        assert!(disks.iter().any(|d| d.id == "sda"));
+        assert!(disks.iter().any(|d| d.id == "sdb"));
+        assert!(!disks.iter().any(|d| d.id == "nvme0n1"));
+    }
+
+    #[test]
+    fn test_get_display_disks_group_bynode_second_node() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 1; // Select second node
+
+        let result = component.get_display_disks();
+        assert!(result.is_some());
+
+        let disks = result.unwrap();
+        // Should only have disks from node-2
+        assert_eq!(disks.len(), 1);
+        assert!(disks.iter().any(|d| d.id == "nvme0n1"));
+        assert!(!disks.iter().any(|d| d.id == "sda"));
+    }
+
+    #[test]
+    fn test_get_display_disks_returns_none_when_tab_out_of_bounds() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 99; // Invalid tab index
+
+        let result = component.get_display_disks();
+        assert!(result.is_none(), "Should return None for invalid tab index");
+    }
+
+    // ==========================================================================
+    // Tests for get_display_volumes()
+    // ==========================================================================
+
+    #[test]
+    fn test_get_display_volumes_single_node_returns_all_volumes() {
+        let component = create_single_node_component();
+
+        let result = component.get_display_volumes();
+        assert!(result.is_some());
+
+        let volumes = result.unwrap();
+        assert_eq!(volumes.len(), 2);
+        assert!(volumes.iter().any(|v| v.id == "STATE"));
+        assert!(volumes.iter().any(|v| v.id == "EPHEMERAL"));
+    }
+
+    #[test]
+    fn test_get_display_volumes_group_interleaved_returns_merged_data() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::Interleaved;
+
+        let result = component.get_display_volumes();
+        assert!(result.is_some());
+
+        let volumes = result.unwrap();
+        // Should have merged volumes from both nodes (3 total)
+        assert_eq!(volumes.len(), 3);
+        // IDs should be prefixed with hostname
+        assert!(volumes
+            .iter()
+            .any(|v| v.id.contains("node-1:") || v.id.contains("node-2:")));
+    }
+
+    #[test]
+    fn test_get_display_volumes_group_bynode_returns_selected_node_data() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 0; // Select first node
+
+        let result = component.get_display_volumes();
+        assert!(result.is_some());
+
+        let volumes = result.unwrap();
+        // Should only have volumes from node-1 (1 volume: STATE)
+        assert_eq!(volumes.len(), 1);
+        assert!(volumes.iter().any(|v| v.id == "STATE"));
+    }
+
+    #[test]
+    fn test_get_display_volumes_group_bynode_second_node() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 1; // Select second node
+
+        let result = component.get_display_volumes();
+        assert!(result.is_some());
+
+        let volumes = result.unwrap();
+        // Should only have volumes from node-2 (2 volumes: STATE, EPHEMERAL)
+        assert_eq!(volumes.len(), 2);
+        assert!(volumes.iter().any(|v| v.id == "STATE"));
+        assert!(volumes.iter().any(|v| v.id == "EPHEMERAL"));
+    }
+
+    #[test]
+    fn test_get_display_volumes_returns_none_when_tab_out_of_bounds() {
+        let mut component = create_group_component();
+        component.group_view_mode = GroupViewMode::ByNode;
+        component.selected_node_tab = 99; // Invalid tab index
+
+        let result = component.get_display_volumes();
+        assert!(result.is_none(), "Should return None for invalid tab index");
+    }
+
+    #[test]
+    fn test_get_display_volumes_group_bynode_with_no_data_for_node() {
+        let nodes = vec![
+            ("node-1".to_string(), "10.0.0.1".to_string()),
+            ("node-2".to_string(), "10.0.0.2".to_string()),
+        ];
+        let mut component = StorageComponent::new_group("Control Plane".to_string(), nodes);
+        component.group_view_mode = GroupViewMode::ByNode;
+
+        // Only add data for node-1
+        component.add_node_storage(
+            "node-1".to_string(),
+            vec![make_disk("sda")],
+            vec![make_volume("STATE")],
+        );
+
+        // Select node-2 which has no data
+        component.selected_node_tab = 1;
+
+        let result = component.get_display_volumes();
+        assert!(
+            result.is_none(),
+            "Should return None when selected node has no data"
+        );
+
+        let disk_result = component.get_display_disks();
+        assert!(
+            disk_result.is_none(),
+            "Should return None for disks when selected node has no data"
+        );
     }
 }


### PR DESCRIPTION

![WindowsTerminal_0Ijiy80Zvf](https://github.com/user-attachments/assets/e3abc24f-3922-4356-a586-155a1180b839)

This PR enables hotkeys (`L`, `p`, `n`, `s`, `d`) to work on group headers (`Control Plane`, `Workers`) in the TUI, showing aggregated views for all nodes in that group. Users can toggle between Interleaved (all nodes merged by timestamp) and ByNode (tabbed per-node) display modes.

### Group Hotkeys
When highlighting a `Control Plane` or `Workers` group header, the following hotkeys now work:

| Hotkey | View | Description |
|--------|------|-------------|
| `L` | Logs | Stream logs from all nodes in the group |
| `p` | Processes | View processes running on all nodes |
| `n` | Network | View network stats from all nodes |
| `s` | Storage | View disks and volumes from all nodes |
| `d` | Diagnostics | Run diagnostic checks on all nodes |

View Modes
- Interleaved (default): All data merged and sorted, with `hostname:` prefix to identify source
- ByNode: Tabbed interface showing one node's data at a time

New Keybindings (Group Views)
| Key | Action |
|-----|--------|
| `v` | Toggle between Interleaved and ByNode view modes |
| `[` | Switch to previous node tab (ByNode mode) |
| `]` | Switch to next node tab (ByNode mode) |

Changes to "core" functionality:
- `action.rs` - Added 5 new action variants (`ShowGroupLogs`, `ShowGroupProcesses`, `ShowGroupNetwork`, `ShowGroupStorage`, `ShowGroupDiagnostics`)
- `cluster.rs` - Added `current_group_nodes()` and `common_services_for_group()` helpers; updated hotkey handlers to detect group selection
- `app.rs` - Added handlers for all group actions with proper client setup for refresh

Components that were added:
- `multi_logs.rs` - Added `GroupViewMode`, multi-node streaming, view toggle, tab navigation
- `processes.rs` - Added group view support with `new_group()`, `refresh_group()`, view toggle
- `network.rs` - Added group view support with `new_group()`, `refresh_group()`, view toggle
- `storage.rs` - Added group view support with `new_group()`, `refresh_group()`, view toggle
- `diagnostics/mod.rs` - Added group view support with `new_group()`, `refresh_group()`, view toggle

### Architecture

```
User presses 'L' on "Control Plane" header
    │
    ▼
cluster.rs: current_group_nodes() returns (group_name, role, nodes)
    │
    ▼
cluster.rs: Emits Action::ShowGroupLogs(group_name, role, nodes, services)
    │
    ▼
app.rs: Creates MultiLogsComponent::new_group()
    │
    ├─► Fetches initial logs from all nodes
    ├─► Sets client for refresh capability
    └─► Starts multi-node streaming
    │
    ▼
multi_logs.rs: Renders with GroupViewMode (Interleaved or ByNode)
```

### View Mode Toggle Flow

```
Interleaved Mode                    ByNode Mode
┌─────────────────────┐            ┌─────────────────────┐
│ All nodes merged    │            │ [node1] [node2] ... │
│ sorted by timestamp │ ◄── v ──►  │ ─────────────────── │
│ hostname:service    │            │ Selected node only  │
└─────────────────────┘            └─────────────────────┘
                                        ▲         ▲
                                        │         │
                                       [←]       [→]
                                   (prev tab) (next tab)
```


Also added some Unit Tests:

| File | Tests | Coverage |
|------|-------|----------|
| `cluster.rs` | 11 | `current_group_nodes()`, `common_services_for_group()` |
| `network.rs` | 6 | `get_display_devices()` |
| `storage.rs` | 12 | `get_display_disks()`, `get_display_volumes()` |
| `diagnostics/mod.rs` | 8 | `get_display_data()` |

No breaking changes. All existing functionality is preserved. Single-node hotkeys work exactly as before. Let me know if you hate anything/everything. I know that this many lines of code increases the maintenance burden, but hopefully this adds enough features to be worth it.


