### PR TITLE
chore: add nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,61 @@ cargo build --release
 ./target/release/talos-pilot
 ```
 
+### NixOS
+
+Talos pilot is available as a Nix flake but can also be run without installing.
+
+#### Run talos-pilot without installing
+
+You can test the app directly by using a nix shell
+
+```bash
+nix shell github:Handfish/talos-pilot
+```
+
+Or run it directly
+
+```bash
+nix run github:Handfish/talos-pilot
+```
+
+#### Usage in flakes
+
+```nix
+# flake.nix
+{
+  inputs = {
+    # ...
+    talos-pilot.url = "github:Handfish/talos-pilot";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      talos-pilot,
+      # ...
+    }:
+    {
+      nixosConfigurations.mymachine = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          {
+            # provides `pkgs.talos-pilot`
+            nixpkgs.overlays = [ talos-pilot.overlays.default ];
+          }
+          (
+            { pkgs, ... }:
+            {
+              # install talos-pilot
+              environment.systemPackages = [ pkgs.talos-pilot ];
+            }
+          )
+        ];
+      };
+    };
+}
+```
+
 ### Requirements
 
 - Valid `~/.talos/config` (talosconfig)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "A flake for talos-pilot, a Talos TUI for real-time node monitoring.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forEachPkgs = f: lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+
+      package =
+        {
+          lib,
+          rustPlatform,
+          protobuf,
+        }:
+        let
+          manifest = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        in
+        rustPlatform.buildRustPackage rec {
+          inherit (manifest.workspace.package) version;
+
+          pname = "talos-pilot";
+          src = ./.;
+
+          cargoDeps = rustPlatform.importCargoLock {
+            lockFile = src + "/Cargo.lock";
+          };
+
+          nativeBuildInputs = [
+            protobuf
+          ];
+
+          meta = {
+            description = "Talos TUI for real-time node monitoring, log streaming, etcd health, and diagnostics";
+            homepage = "https://github.com/Handfish/talos-pilot";
+            license = with lib.licenses; [ mit ];
+            mainProgram = "talos-pilot";
+          };
+        };
+    in
+    {
+      packages = forEachPkgs (pkgs: rec {
+        talos-pilot = pkgs.callPackage package { inherit (pkgs) protobuf; };
+        default = talos-pilot;
+      });
+      devShells = forEachPkgs (pkgs: {
+        default = pkgs.mkShell {
+          # automatically pulls nativeBuildInputs + buildInputs
+          inputsFrom = [ (pkgs.callPackage package { inherit (pkgs) protobuf; }) ];
+        };
+      });
+      overlays.default = final: _: {
+        talos-pilot = final.callPackage package { };
+      };
+    };
+}


### PR DESCRIPTION
Adds nix flake, and relevant documentation how to install/use talos-pilot on Nix.